### PR TITLE
Removed form->isSubmitted() checks

### DIFF
--- a/src/AppBundle/Controller/Admin/BlogController.php
+++ b/src/AppBundle/Controller/Admin/BlogController.php
@@ -64,7 +64,7 @@ class BlogController extends Controller
 
         $form->handleRequest($request);
 
-        if ($form->isSubmitted() && $form->isValid()) {
+        if ($form->isValid()) {
             $post->setSlug($this->get('slugger')->slugify($post->getTitle()));
 
             $em = $this->getDoctrine()->getManager();
@@ -115,7 +115,7 @@ class BlogController extends Controller
 
         $editForm->handleRequest($request);
 
-        if ($editForm->isSubmitted() && $editForm->isValid()) {
+        if ($editForm->isValid()) {
             $post->setSlug($this->get('slugger')->slugify($post->getTitle()));
             $em->flush();
 

--- a/src/AppBundle/Controller/BlogController.php
+++ b/src/AppBundle/Controller/BlogController.php
@@ -67,7 +67,7 @@ class BlogController extends Controller
 
         $form->handleRequest($request);
 
-        if ($form->isSubmitted() && $form->isValid()) {
+        if ($form->isValid()) {
             /** @var Comment $comment */
             $comment = $form->getData();
             $comment->setAuthorEmail($this->getUser()->getEmail());


### PR DESCRIPTION
$form->isValid() already check if a form has been validated or not.

So I think it's not required to do this check (see: https://github.com/symfony/Form/blob/master/Form.php#L769)

