### PR TITLE
Optimized slugger: trimming dash at the beginning & end and removed doubles dashes

### DIFF
--- a/src/AppBundle/Tests/Utils/SluggerTest.php
+++ b/src/AppBundle/Tests/Utils/SluggerTest.php
@@ -42,7 +42,9 @@ class SluggerTest extends \PHPUnit_Framework_TestCase
         return array(
             array('Lorem Ipsum'     , 'lorem-ipsum'),
             array('  Lorem Ipsum  ' , 'lorem-ipsum'),
-            array(' lOrEm  iPsUm  ' , 'lorem--ipsum'),
+            array(' lOrEm  iPsUm  ' , 'lorem-ipsum'),
+            array('!Lorem Ipsum!'   , 'lorem-ipsum'),
+            array('lorem-ipsum'     , 'lorem-ipsum'),
         );
     }
 }

--- a/src/AppBundle/Utils/Slugger.php
+++ b/src/AppBundle/Utils/Slugger.php
@@ -22,6 +22,6 @@ class Slugger
 {
     public function slugify($string)
     {
-        return preg_replace('/[^a-z0-9]/', '-', strtolower(trim(strip_tags($string))));
+        return trim(preg_replace('/[^a-z0-9]+/', '-', strtolower(trim(strip_tags($string)))), '-');
     }
 }


### PR DESCRIPTION
Hello,

I found the symfony-demo repository and the idea behind is great.

also in the symfony best practices, the slugger has 2 problems in my opinion.
* several dashes like lorem--ipsum
* dashes at the begin or end like -lorem-ipsum-

here is my litte pull request.
sebastian