### PR TITLE
Remove redundant function call

### DIFF
--- a/src/AppBundle/Utils/Slugger.php
+++ b/src/AppBundle/Utils/Slugger.php
@@ -22,6 +22,6 @@ class Slugger
 {
     public function slugify($string)
     {
-        return trim(preg_replace('/[^a-z0-9]+/', '-', strtolower(trim(strip_tags($string)))), '-');
+        return trim(preg_replace('/[^a-z0-9]+/', '-', strtolower(strip_tags($string))), '-');
     }
 }


### PR DESCRIPTION
After https://github.com/symfony/symfony-demo/pull/15, the inner `trim()` call is no longer required as the outer one already trims all dashes.