### PR TITLE
Changed the README a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,36 +10,36 @@ Installation
 This is a fully-functional Symfony project. If you want to get it running,
 you have two alternatives:
 
-### 1) Use the Symfony Installer
+### A) Using the Symfony Installer
 
 First, install the [Symfony Installer](https://github.com/symfony/symfony-installer).
 Then, download and install the Symfony Demo Application executing this command
 anywhere in your system:
 
 ```bash
-# NOTE: this command doesn't work yet. It will be added to the installer soon.
 $ symfony demo
+
+# if you're using Windows:
+$ php symfony demo
 ```
 
-### 2) Clone the Repository
+### B) Using Git
 
 Alternatively, you can clone this repository using Git. Open up a terminal and
 execute the following command:
 
-```
+```bash
 $ git clone https://github.com/symfony/symfony-demo
 ````
 
-Next, move into the project and use Composer to download the application
-dependencies:
+Next, [install Composer](http://symfony.com/doc/current/cookbook/composer.html)
+(if you haven't done this already), move into the project and use Composer to
+download the application dependencies:
 
-```
+```bash
 $ cd symfony-demo/
 $ composer install
 ```
-
-Make sure you [install Composer](http://getcomposer.org/download/) before
-running this.
 
 Usage
 -----
@@ -47,14 +47,14 @@ Usage
 If you have PHP 5.4 or higher, there is no need to configure a virtual host
 in your web server to access the application. Just use the built-in web server:
 
-```
+```bash
 $ cd symfony-demo/
 $ php app/console server:run
 ```
 
 This will start a web server that's accessible at http://localhost:8000.
 It will just sit and wait forever, so don't expect it to finish. You can
-quit it later when you want by pressing `ctrl + c`.
+quit it later when you want by pressing `Ctrl + c`.
 
 > **NOTE**
 >
@@ -62,6 +62,4 @@ quit it later when you want by pressing `ctrl + c`.
 > directory of the project. For more details, see:
 > http://symfony.com/doc/current/cookbook/configuration/web_server_configuration.html
 
-You're all done! Now just load up the application in your browser:
-
-http://localhost:8000
+You're all done! Now just load up the application in your browser: http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -52,14 +52,12 @@ $ cd symfony-demo/
 $ php app/console server:run
 ```
 
-This will start a web server that's accessible at http://localhost:8000.
-It will just sit and wait forever, so don't expect it to finish. You can
-quit it later when you want by pressing `Ctrl + c`.
+This command will start a web server for the Symfony application. Now you can access
+the application in your browser at <http://localhost:8000>. You can stop the built-in
+web server by pressing `Ctrl + C` while you're in the terminal.
 
 > **NOTE**
 >
 > If you're using PHP 5.3, configure your web server to point at the `web/`
 > directory of the project. For more details, see:
 > http://symfony.com/doc/current/cookbook/configuration/web_server_configuration.html
-
-You're all done! Now just load up the application in your browser: http://localhost:8000


### PR DESCRIPTION
* A bit personally, but an ordered list using numbers seem to indicate a list of steps, while an ordered list using characters indicates different options;
* The demo command was added to the symfony installer (and is available if you download it from symfony.com);
* Some code blocks used the bash highlighting, while others didn't;
* Link to symfony's installing composer guide, as it explains how to install globally (composer still doesn't document this on its download page).

Btw, why does the guide use `server:run` and not `server:start`? (maybe to be compatible with Windows users?)