### PR TITLE
Fix the escaping of the source code when displaying it

### DIFF
--- a/app/Resources/views/default/_source_code.html.twig
+++ b/app/Resources/views/default/_source_code.html.twig
@@ -20,10 +20,10 @@
 
                 <div class="modal-body">
                     <h3>Controller code <small class="pull-right">{{ controller_file_path }}</small></h3>
-                    <pre><code class="php">{{ controller_source_code|raw }}</code></pre>
+                    <pre><code class="php">{{ controller_source_code }}</code></pre>
 
                     <h3>Twig template code <small class="pull-right">{{ template_file_path }}</small></h3>
-                    <pre><code class="twig">{{ template_source_code|raw }}</code></pre>
+                    <pre><code class="twig">{{ template_source_code }}</code></pre>
                 </div>
             </div>
         </div>

--- a/src/AppBundle/Twig/SourceCodeExtension.php
+++ b/src/AppBundle/Twig/SourceCodeExtension.php
@@ -50,7 +50,7 @@ class SourceCodeExtension extends \Twig_Extension
         return $twig->render('default/_source_code.html.twig', array(
             'controller_source_code' => $this->getControllerCode(),
             'controller_file_path'   => $this->getControllerRelativePath(),
-            'template_source_code'   => htmlspecialchars($this->getTemplateCode(), ENT_QUOTES, 'UTF-8'),
+            'template_source_code'   => $this->getTemplateCode(),
             'template_file_path'     => $this->getTemplateRelativePath(),
         ));
     }


### PR DESCRIPTION
The source code of the controller cannot be considered as being safe HTML. It needs to be escaped.

This also moves the escaping of the template source code from the extension to the template rendering it, where it belongs (which also avoid using ``|raw``, which is flagged by Insight as being dangerous because it expects the escaping to happen elsewhere, see the first point about the controller source code)