### PR TITLE
Updated Composer requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     },
     "require": {
         "php"                                  : ">=5.3.3",
-        "ext-sqlite"                           : "*",
+        "ext-pdo_sqlite"                       : "*",
         "doctrine/doctrine-bundle"             : "~1.2",
         "doctrine/doctrine-fixtures-bundle"    : "~2.2",
         "doctrine/orm"                         : "~2.2,>=2.2.3",

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
     },
     "require": {
         "php"                                  : ">=5.3.3",
+        "ext-sqlite"                           : "*",
         "doctrine/doctrine-bundle"             : "~1.2",
         "doctrine/doctrine-fixtures-bundle"    : "~2.2",
         "doctrine/orm"                         : "~2.2,>=2.2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "300a2d867cd12adc305cc86547b79ccd",
+    "hash": "58f0c87bf7b054265a5e9947b947a13f",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -1930,7 +1930,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.3",
+        "ext-pdo_sqlite": "*"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
First of all, **we can't merge this pull request**. I've just opened to get your feedback and comments about it.

In my computer, the demo application works perfectly and I see no errors or warnings. However, if I set a PHP extension constraint in PHP, I get the following Composer errors:

### ext-pdo-sqlite

![ext-pdo-sqlite](https://cloud.githubusercontent.com/assets/73419/7061612/b4386c0c-de94-11e4-9771-e566e3b3b64f.png)

### ext-sqlite

![ext-sqlite](https://cloud.githubusercontent.com/assets/73419/7061614/b525af1c-de94-11e4-8d05-828765f3b063.png)