### PR TITLE
Fixed backend design for the listing actions

### DIFF
--- a/app/Resources/assets/scss/main.scss
+++ b/app/Resources/assets/scss/main.scss
@@ -235,7 +235,9 @@ body#comment_form_error {
 // Page: 'admin_post_index'
 // --------------------------------------------------
 body#admin_post_index {
-    tbody td {
+    .item-actions {
+        white-space: nowrap;
+
         a.btn + a.btn {
             margin-left: 4px;
         }

--- a/app/Resources/views/admin/blog/index.html.twig
+++ b/app/Resources/views/admin/blog/index.html.twig
@@ -21,15 +21,17 @@
                 <td>{{ post.authorEmail }}</td>
                 <td>{% if post.publishedAt %}{{ post.publishedAt|date('Y-m-d H:i') }}{% endif %}</td>
                 <td>
-                    <a href="{{ path('admin_post_show', { id: post.id }) }}" class="btn btn-sm btn-default">
-                        {{ 'action.show'|trans }}
-                    </a>
-
-                    {% if post.isAuthor(app.user) %}
-                        <a href="{{ path('admin_post_edit', { id: post.id }) }}" class="btn btn-sm btn-primary">
-                            <i class="fa fa-edit"></i> {{ 'action.edit'|trans }}
+                    <div class="item-actions">
+                        <a href="{{ path('admin_post_show', { id: post.id }) }}" class="btn btn-sm btn-default">
+                            {{ 'action.show'|trans }}
                         </a>
-                    {% endif %}
+
+                        {% if post.isAuthor(app.user) %}
+                            <a href="{{ path('admin_post_edit', { id: post.id }) }}" class="btn btn-sm btn-primary">
+                                <i class="fa fa-edit"></i> {{ 'action.edit'|trans }}
+                            </a>
+                        {% endif %}
+                    </div>
                 </td>
             </tr>
         {% endfor %}

--- a/web/css/app.css
+++ b/web/css/app.css
@@ -7093,5 +7093,7 @@ body#blog_post_show .post-comment {
 body#comment_form_error h1.text-danger {
   margin-bottom: 1em; }
 
-body#admin_post_index tbody td a.btn + a.btn {
-  margin-left: 4px; }
+body#admin_post_index .item-actions {
+  white-space: nowrap; }
+  body#admin_post_index .item-actions a.btn + a.btn {
+    margin-left: 4px; }


### PR DESCRIPTION
I was playing with the Russian translation kindly provided by @bocharsky-bw and I noticed the following issue:

![before](https://cloud.githubusercontent.com/assets/73419/7233447/8180a7a2-e781-11e4-939f-b8321c14245d.png)

After this PR, the actions should always be correctly displayed:

![after](https://cloud.githubusercontent.com/assets/73419/7233456/8a47b934-e781-11e4-8a42-29a4b172da43.png)
