### PR TITLE
Removed unneeded Request argument

### DIFF
--- a/src/AppBundle/Controller/SecurityController.php
+++ b/src/AppBundle/Controller/SecurityController.php
@@ -27,7 +27,7 @@ class SecurityController extends Controller
     /**
      * @Route("/login", name="security_login_form")
      */
-    public function loginAction(Request $request)
+    public function loginAction()
     {
         $helper = $this->get('security.authentication_utils');
 


### PR DESCRIPTION
The assigned Request instance is currently not needed in the login action and thus should be removed from the methods signature.