### PR TITLE
Remove unnecessary call of isSubmitted method on forms

### DIFF
--- a/src/AppBundle/Controller/Admin/BlogController.php
+++ b/src/AppBundle/Controller/Admin/BlogController.php
@@ -70,7 +70,7 @@ class BlogController extends Controller
 
         $form->handleRequest($request);
 
-        if ($form->isSubmitted() && $form->isValid()) {
+        if ($form->isValid()) {
             $post->setSlug($this->get('slugger')->slugify($post->getTitle()));
 
             $em = $this->getDoctrine()->getManager();
@@ -122,7 +122,7 @@ class BlogController extends Controller
 
         $editForm->handleRequest($request);
 
-        if ($editForm->isSubmitted() && $editForm->isValid()) {
+        if ($editForm->isValid()) {
             $post->setSlug($this->get('slugger')->slugify($post->getTitle()));
             $em->flush();
 

--- a/src/AppBundle/Controller/BlogController.php
+++ b/src/AppBundle/Controller/BlogController.php
@@ -73,7 +73,7 @@ class BlogController extends Controller
 
         $form->handleRequest($request);
 
-        if ($form->isSubmitted() && $form->isValid()) {
+        if ($form->isValid()) {
             /** @var Comment $comment */
             $comment = $form->getData();
             $comment->setAuthorEmail($this->getUser()->getEmail());


### PR DESCRIPTION
The `isSubmitted` already check in `isValid` method (https://github.com/symfony/Form/blob/master/Form.php#L771) and not need in this statement.