### PR TITLE
Change URL to login form documentation

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -22,7 +22,7 @@ security:
             anonymous: true
 
             # This allows the user to login by submitting a username and password
-            # Reference: http://symfony.com/doc/current/cookbook/security/form_login.html
+            # Reference: http://symfony.com/doc/current/cookbook/security/form_login_setup.html
             form_login:
                 # The route name that the login form submits to
                 check_path: security_login_check


### PR DESCRIPTION
Although `http://symfony.com/doc/current/cookbook/security/form_login.html` is a valid url, I think `http://symfony.com/doc/current/cookbook/security/form_login_setup.html` is more applicable here.