### PR TITLE
Improve the checking if the current request is a master request in the ControllerListener.

### DIFF
--- a/src/AppBundle/EventListener/ControllerListener.php
+++ b/src/AppBundle/EventListener/ControllerListener.php
@@ -11,7 +11,6 @@
 
 namespace AppBundle\EventListener;
 
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 use AppBundle\Twig\SourceCodeExtension;
 
@@ -41,7 +40,7 @@ class ControllerListener
         // this check is needed because in Symfony a request can perform any
         // number of sub-requests. See
         // http://symfony.com/doc/current/components/http_kernel/introduction.html#sub-requests
-        if (HttpKernelInterface::MASTER_REQUEST === $event->getRequestType()) {
+        if ($event->isMasterRequest()) {
             $this->twigExtension->setController($event->getController());
         }
     }


### PR DESCRIPTION
There is a more convenient way to check whether the current request is a master request. See http://api.symfony.com/2.7/Symfony/Component/HttpKernel/Event/KernelEvent.html#method_isMasterRequest