### PR TITLE
Add the app_ prefix to  form field types to avoid collisions

### DIFF
--- a/src/AppBundle/Form/CommentType.php
+++ b/src/AppBundle/Form/CommentType.php
@@ -52,6 +52,6 @@ class CommentType extends AbstractType
      */
     public function getName()
     {
-        return 'comment';
+        return 'app_comment';
     }
 }

--- a/src/AppBundle/Form/PostType.php
+++ b/src/AppBundle/Form/PostType.php
@@ -59,6 +59,6 @@ class PostType extends AbstractType
      */
     public function getName()
     {
-        return 'post';
+        return 'app_post';
     }
 }


### PR DESCRIPTION
Best Practice
http://symfony.com/doc/current/best_practices/forms.html#custom-form-field-types 