### PR TITLE
Make the application name translatable

### DIFF
--- a/app/Resources/translations/messages.en.xliff
+++ b/app/Resources/translations/messages.en.xliff
@@ -19,6 +19,11 @@
                 <target>MIT License</target>
             </trans-unit>
 
+            <trans-unit id="app.name">
+                <source>app.name</source>
+                <target>Symfony Demo Application</target>
+            </trans-unit>
+
             <trans-unit id="title.homepage">
                 <source>title.homepage</source>
                 <target><![CDATA[Welcome to the <strong>Symfony Demo Application</strong>]]></target>

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -7,7 +7,7 @@
 <html>
     <head>
         <meta charset="UTF-8" />
-        <title>{% block title %}Symfony Demo Application{% endblock %}</title>
+        <title>{% block title %}{{ 'app.name'|trans }}{% endblock %}</title>
 
         {% block stylesheets %}
         {# uncomment the following lines to compile SCSS assets with Assetic
@@ -35,7 +35,7 @@
                     <div class="container">
                         <div class="navbar-header">
                             <a class="navbar-brand" href="{{ path('homepage') }}">
-                                Symfony Demo Application
+                                {{ 'app.name'|trans }}
                             </a>
 
                             <button type="button" class="navbar-toggle"


### PR DESCRIPTION
While I was doing the Brazilian Portuguese translation I realized that the application name on the page title and on the navbar couldn't be translated. Since it is a descriptive name, I think it would be nice for it to be translatable.