### PR TITLE
Remove the broken composer script for root-package install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,6 @@
         "sensio/generator-bundle": "~2.3"
     },
     "scripts": {
-        "post-root-package-install": [
-            "SymfonyStandard\\Composer::hookRootPackageInstall"
-        ],
         "post-install-cmd": [
             "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "0bf06af36fa5f091dd2b3733278b7f9c",
+    "hash": "8819bcb22268fbc47cb7eb5ac24d6170",
     "packages": [
         {
             "name": "doctrine/annotations",


### PR DESCRIPTION
New projects generated by the installer suffer from this issue because of https://github.com/sensiolabs/SensioDistributionBundle/issues/215 (see https://github.com/symfony/symfony-installer/issues/110).
this cleans the composer.json of this project.