### PR TITLE
Italian translation

### DIFF
--- a/app/Resources/translations/messages.it.xliff
+++ b/app/Resources/translations/messages.it.xliff
@@ -29,7 +29,7 @@
             </trans-unit>
             <trans-unit id="title.controller_code">
                 <source>title.controller_code</source>
-                <target>Codice del controller</target>
+                <target>Codice del controllore</target>
             </trans-unit>
             <trans-unit id="title.twig_template_code">
                 <source>title.twig_template_code</source>
@@ -202,7 +202,7 @@
             </trans-unit>
             <trans-unit id="help.show_code">
                 <source>help.show_code</source>
-                <target><![CDATA[Clicca su questo pulsante per mostare il codice sorgente dei <strong>Controller</strong> e <strong>template</strong> usati per effettuare il render di questa pagina.]]></target>
+                <target><![CDATA[Clicca su questo pulsante per mostare il codice sorgente dei <strong>controllori</strong> e <strong>template</strong> usati per effettuare il render di questa pagina.]]></target>
             </trans-unit>
             <trans-unit id="help.browse_app">
                 <source>help.browse_app</source>

--- a/app/Resources/translations/messages.it.xliff
+++ b/app/Resources/translations/messages.it.xliff
@@ -1,0 +1,241 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" target-language="it" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="note">
+                <source>note</source>
+                <target>NOTE</target>
+            </trans-unit>
+            <trans-unit id="tip">
+                <source>tip</source>
+                <target>SUGGERIMENTO</target>
+            </trans-unit>
+            <trans-unit id="not_available">
+                <source>not_available</source>
+                <target>Non disponibile</target>
+            </trans-unit>
+            <trans-unit id="mit_license">
+                <source>mit_license</source>
+                <target>Licenza MIT</target>
+            </trans-unit>
+
+            <trans-unit id="title.homepage">
+                <source>title.homepage</source>
+                <target><![CDATA[Benvenuto nell'applicazione <strong>Symfony Demo</strong>]]></target>
+            </trans-unit>
+            <trans-unit id="title.source_code">
+                <source>title.source_code</source>
+                <target>Codice sorgente usato per effettuare il render di questa pagina</target>
+            </trans-unit>
+            <trans-unit id="title.controller_code">
+                <source>title.controller_code</source>
+                <target>Codice del controller</target>
+            </trans-unit>
+            <trans-unit id="title.twig_template_code">
+                <source>title.twig_template_code</source>
+                <target>Codice del template Twig</target>
+            </trans-unit>
+            <trans-unit id="title.login">
+                <source>title.login</source>
+                <target>Accesso sicuro</target>
+            </trans-unit>
+            <trans-unit id="title.post_list">
+                <source>title.post_list</source>
+                <target>Lista dei post</target>
+            </trans-unit>
+            <trans-unit id="title.edit_post">
+                <source>title.edit_post</source>
+                <target>Modifica post #%id%</target>
+            </trans-unit>
+            <trans-unit id="title.add_comment">
+                <source>title.add_comment</source>
+                <target>Aggiungi un commento</target>
+            </trans-unit>
+            <trans-unit id="title.comment_error">
+                <source>title.comment_error</source>
+                <target>C'è stato un errore nella pubblicazione del tuo commento</target>
+            </trans-unit>
+
+            <trans-unit id="action.show">
+                <source>action.show</source>
+                <target>Mostra</target>
+            </trans-unit>
+            <trans-unit id="action.show_code">
+                <source>action.show_code</source>
+                <target>Mostra codice</target>
+            </trans-unit>
+            <trans-unit id="action.edit">
+                <source>action.edit</source>
+                <target>Modifica</target>
+            </trans-unit>
+            <trans-unit id="action.edit_post">
+                <source>action.edit_post</source>
+                <target>Modifica post</target>
+            </trans-unit>
+            <trans-unit id="action.save">
+                <source>action.save</source>
+                <target>Salva cambiamenti</target>
+            </trans-unit>
+            <trans-unit id="action.delete_post">
+                <source>action.delete_post</source>
+                <target>Elimina post</target>
+            </trans-unit>
+            <trans-unit id="action.create_post">
+                <source>action.create_post</source>
+                <target>Crea un nuovo post</target>
+            </trans-unit>
+            <trans-unit id="label.create_post">
+                <source>label.create_post</source>
+                <target>Crea post</target>
+            </trans-unit>
+            <trans-unit id="action.back_to_list">
+                <source>action.back_to_list</source>
+                <target>Ritorna alla lista dei post</target>
+            </trans-unit>
+            <trans-unit id="action.publish_comment">
+                <source>action.publish_comment</source>
+                <target>Pubblica commento</target>
+            </trans-unit>
+            <trans-unit id="action.sign_in">
+                <source>action.sign_in</source>
+                <target>Accedi</target>
+            </trans-unit>
+            <trans-unit id="action.browse_app">
+                <source>action.browse_app</source>
+                <target>Naviga nell'applicazione</target>
+            </trans-unit>
+            <trans-unit id="action.browse_admin">
+                <source>action.browse_admin</source>
+                <target>Naviga nel pannello di controllo</target>
+            </trans-unit>
+
+            <trans-unit id="label.title">
+                <source>label.title</source>
+                <target>Titolo</target>
+            </trans-unit>
+            <trans-unit id="label.author">
+                <source>label.author</source>
+                <target>Autore</target>
+            </trans-unit>
+            <trans-unit id="label.author_email">
+                <source>label.author_email</source>
+                <target>Email dell'autore</target>
+            </trans-unit>
+            <trans-unit id="label.username">
+                <source>label.username</source>
+                <target>Nome utente</target>
+            </trans-unit>
+            <trans-unit id="label.password">
+                <source>label.password</source>
+                <target>Password</target>
+            </trans-unit>
+            <trans-unit id="label.role">
+                <source>label.role</source>
+                <target>Ruolo</target>
+            </trans-unit>
+            <trans-unit id="label.content">
+                <source>label.content</source>
+                <target>Contenuto</target>
+            </trans-unit>
+            <trans-unit id="label.summary">
+                <source>label.summary</source>
+                <target>Descrizione</target>
+            </trans-unit>
+            <trans-unit id="label.published_at">
+                <source>label.published_at</source>
+                <target>Data pubblicazione</target>
+            </trans-unit>
+            <trans-unit id="label.actions">
+                <source>label.actions</source>
+                <target>Azioni</target>
+            </trans-unit>
+            <trans-unit id="title.post_new">
+                <source>title.post_new</source>
+                <target>Creazione post</target>
+            </trans-unit>
+            <trans-unit id="action.edit_contents">
+                <source>action.edit_contents</source>
+                <target>Modifica contenuti</target>
+            </trans-unit>
+
+            <trans-unit id="menu.post_list">
+                <source>menu.post_list</source>
+                <target>Lista post</target>
+            </trans-unit>
+            <trans-unit id="menu.back_to_blog">
+                <source>menu.back_to_blog</source>
+                <target>Ritorna al blog</target>
+            </trans-unit>
+            <trans-unit id="menu.homepage">
+                <source>menu.homepage</source>
+                <target>Homepage</target>
+            </trans-unit>
+            <trans-unit id="menu.admin">
+                <source>menu.admin</source>
+                <target>Pannello di controllo</target>
+            </trans-unit>
+            <trans-unit id="menu.logout">
+                <source>menu.logout</source>
+                <target>Esci</target>
+            </trans-unit>
+
+            <trans-unit id="post.to_publish_a_comment">
+                <source>post.to_publish_a_comment</source>
+                <target>per pubblicare un commento</target>
+            </trans-unit>
+            <trans-unit id="post.num_comments">
+                <source>post.num_comments</source>
+                <target>%count% commento|%count% commenti</target>
+            </trans-unit>
+            <trans-unit id="post.commented_on">
+                <source>post.commented_on</source>
+                <target>ha commentato il</target>
+            </trans-unit>
+            <trans-unit id="post.no_comments">
+                <source>post.no_comments</source>
+                <target>Commenta per primo.</target>
+            </trans-unit>
+
+            <trans-unit id="help.app_description">
+                <source>help.app_description</source>
+                <target><![CDATA[Questa è un'<strong>applicazione demo</strong> creata con il Framework Symfony per illustrare il modo raccomandato per sviluppare applicazioni con Symfony.]]></target>
+            </trans-unit>
+            <trans-unit id="help.show_code">
+                <source>help.show_code</source>
+                <target><![CDATA[Clicca su questo pulsante per mostare il codice sorgente dei <strong>Controller</strong> e <strong>template</strong> usati per effettuare il render di questa pagina.]]></target>
+            </trans-unit>
+            <trans-unit id="help.browse_app">
+                <source>help.browse_app</source>
+                <target><![CDATA[Naviga nella <strong>sezione pubblica</strong> dell'applicazione demo.]]></target>
+            </trans-unit>
+            <trans-unit id="help.browse_admin">
+                <source>help.browse_admin</source>
+                <target><![CDATA[Naviga nel <strong>pannello di controllo</strong> dell'applicazione demo.]]></target>
+            </trans-unit>
+            <trans-unit id="help.login_users">
+                <source>help.login_users</source>
+                <target>Prova uno dei seguenti utenti</target>
+            </trans-unit>
+            <trans-unit id="help.role_user">
+                <source>help.role_user</source>
+                <target>utente normale</target>
+            </trans-unit>
+            <trans-unit id="help.role_admin">
+                <source>help.role_admin</source>
+                <target>amministratore</target>
+            </trans-unit>
+            <trans-unit id="help.reload_fixtures">
+                <source>help.reload_fixtures</source>
+                <target>Se questi utenti non dovessero funzionare, ricarica i dati dell'applicazione eseguendo questo comando dal terminale:</target>
+            </trans-unit>
+            <trans-unit id="help.add_user">
+                <source>help.add_user</source>
+                <target>Se vuoi aggiungere nuovi utenti, esegui quest'altro comando:</target>
+            </trans-unit>
+            <trans-unit id="help.more_information">
+                <source>help.more_information</source>
+                <target><![CDATA[Per altre informazioni, visita la <a href="http://symfony.com/doc">documentazione di Symfony</a>.]]></target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/app/Resources/translations/validators.it.xliff
+++ b/app/Resources/translations/validators.it.xliff
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" target-language="it" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="post.blank_summary">
+                <source>post.blank_summary</source>
+                <target>Da' una descrizione al tuo post!</target>
+            </trans-unit>
+            <trans-unit id="post.too_short_content">
+                <source>post.too_short_content</source>
+                <target>Il contenuto del post è troppo breve (minimo {{ limit }} caratteri)</target>
+            </trans-unit>
+            <trans-unit id="comment.blank">
+                <source>comment.blank</source>
+                <target>Per favore non lasciare in bianco il tuo commento!</target>
+            </trans-unit>
+            <trans-unit id="comment.too_short">
+                <source>comment.too_short</source>
+                <target>Il commento è troppo breve (minimo {{ limit }} caratteri)</target>
+            </trans-unit>
+            <trans-unit id="comment.too_long">
+                <source>comment.too_long</source>
+                <target>Il commento è troppo lungo (massimo {{ limit }} caratteri)</target>
+            </trans-unit>
+            <trans-unit id="comment.is_spam">
+                <source>comment.is_spam</source>
+                <target>Il contenuto di questo commento è considerato come spam.</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -14,7 +14,7 @@ imports:
 # See http://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
 parameters:
     # This parameter defines the codes of the locales (languages) enabled in the application
-    app_locales: en|fr|de|es|cs|ru|uk|ro|pt_BR
+    app_locales: en|fr|de|es|cs|ru|uk|ro|pt_BR|it
 
 # Basic configuration for the Symfony framework features
 framework:


### PR DESCRIPTION
Italian XLIFF language files added, and config.yml updated.

On a side note, I added "it" after all previous languages, but for readibility purposes I suggest ordering the list alphabetically, with "en" possibly kept at the front.