### PR TITLE
Remove point to PHP platform from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "ext-pdo_sqlite"                       : "*",
         "doctrine/doctrine-bundle"             : "~1.5",
         "doctrine/doctrine-fixtures-bundle"    : "~2.2",
-        "doctrine/orm"                         : "~2.4",
+        "doctrine/orm"                         : "~2.4.7",
         "erusev/parsedown"                     : "~1.5",
         "incenteev/composer-parameter-handler" : "~2.1",
         "ircmaxell/password-compat"            : "~1.0",
@@ -47,10 +47,7 @@
         ]
     },
     "config": {
-        "bin-dir": "bin",
-        "platform": {
-            "php": "5.3.9"
-        }
+        "bin-dir": "bin"
     },
     "extra": {
         "symfony-app-dir": "app",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "252b684b5ecfedd66558dbf523c883aa",
+    "hash": "58dc2c2379791cfbcde5f43e582bcfe4",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -1980,8 +1980,5 @@
         "php": ">=5.3.9",
         "ext-pdo_sqlite": "*"
     },
-    "platform-dev": [],
-    "platform-overrides": {
-        "php": "5.3.9"
-    }
+    "platform-dev": []
 }


### PR DESCRIPTION
The main problem is to have `v5.6.4` PHP version on my local machine I can't add other bundles depend of PHP `>v5.3.9` (it points in platform section of `composer.json`) and I have next error when doing `$ composer require knplabs/doctrine-behaviors:dev-master`:
```
  Problem 1
    - Installation request for knplabs/doctrine-behaviors dev-master -> satisfiable by knplabs/doctrine-behaviors[dev-master].
    - knplabs/doctrine-behaviors dev-master requires php >=5.4 -> your PHP version (5.6.4-4ubuntu6.2) does not satisfy that requirement.
```
