### PR TITLE
Fix slug bug when using non alphabet title

### DIFF
--- a/src/AppBundle/Tests/Utils/SluggerTest.php
+++ b/src/AppBundle/Tests/Utils/SluggerTest.php
@@ -44,6 +44,12 @@ class SluggerTest extends \PHPUnit_Framework_TestCase
             array(' lOrEm  iPsUm  ' , 'lorem-ipsum'),
             array('!Lorem Ipsum!'   , 'lorem-ipsum'),
             array('lorem-ipsum'     , 'lorem-ipsum'),
+            array('русский язык'    , 'русский-язык'),
+            array('  русский язык  ', 'русский-язык'),
+            array('日本語'           , '日本語'),
+            array(' 日本語 '         , '日本語'),
+            array('  日 本 語!'       , '日-本-語'),
+            array('日本語#&'         , '日本語'),
         );
     }
 }

--- a/src/AppBundle/Utils/Slugger.php
+++ b/src/AppBundle/Utils/Slugger.php
@@ -22,6 +22,6 @@ class Slugger
 {
     public function slugify($string)
     {
-        return trim(preg_replace('/[^a-z0-9]+/', '-', strtolower(strip_tags($string))), '-');
+        return trim(preg_replace('/[\s\!\#\&]+/', '-', mb_strtolower(strip_tags($string))), '-');
     }
 }


### PR DESCRIPTION
If you create a post using non alphabet title, the slug of this new post will be set empty.
http://127.0.0.1:8000/en/admin/post/new

For example:
In case I use 'русский язык' for a title of a new post, the post will be create with no error.
But, the slug will be set empty.
Therefore, indexAction in BlogController will return an error like this:
An exception has been thrown during the rendering of a template ("Parameter "slug" for route "blog_post" must match "[^/]++" ("" given) to generate a corresponding URL.") in blog/index.html.twig at line 9.

This pull request fix the problem.