### PR TITLE
Move independent of env parameter to config.yml

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -15,6 +15,7 @@ imports:
 parameters:
     # This parameter defines the codes of the locales (languages) enabled in the application
     app_locales: en|fr|de|es|cs|ru|uk|ro|pt_BR|pl|it|ja
+    app.notifications.email_sender: anonymous@example.com
 
 # Basic configuration for the Symfony framework features
 framework:

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -1,6 +1,3 @@
-parameters:
-    app.notifications.email_sender: anonymous@example.com
-
 services:
     # First we define some basic services to make these utilities available in
     # the entire application


### PR DESCRIPTION
I think better to move this parameter to `app/config/config.yml` assuming that we added there parameters which independent of environment to locate them in one place.