### PR TITLE
Remove published date creation repeatedly

### DIFF
--- a/src/AppBundle/Controller/BlogController.php
+++ b/src/AppBundle/Controller/BlogController.php
@@ -79,7 +79,6 @@ class BlogController extends Controller
             $comment = $form->getData();
             $comment->setAuthorEmail($this->getUser()->getEmail());
             $comment->setPost($post);
-            $comment->setPublishedAt(new \DateTime());
 
             $em = $this->getDoctrine()->getManager();
             $em->persist($comment);


### PR DESCRIPTION
We already create it in [AppBundle\Entity\Comment::__construct](https://github.com/symfony/symfony-demo/blob/master/src/AppBundle/Entity/Comment.php#L70)