### PR TITLE
Comment framework.ide setting

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -24,7 +24,7 @@ framework:
     # Supported values are 'textmate', 'macvim', 'emacs' and 'sublime' shortcuts
     # and any custom configuration string, such as: "phpstorm://open?file=%%f&line=%%l"
     # See http://symfony.com/doc/current/reference/configuration/framework.html#ide
-    ide: sublime
+    #ide: sublime
 
     # esi:             ~
     translator:      { fallback: "%locale%" }


### PR DESCRIPTION
This setting takes priority over any locally configured one, and thus prevents using source links with the demo app.