### PR TITLE
Rename Twig extensions according to best practices

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -9,9 +9,9 @@ services:
 
     # These are the Twig extensions that create new filters and functions for
     # using them in the templates
-    app.twig.app_extension:
+    app.twig.markdown_extension:
         public:    false
-        class:     AppBundle\Twig\AppExtension
+        class:     AppBundle\Twig\MarkdownExtension
         arguments: ["@markdown"]
         tags:
             - { name: twig.extension }

--- a/src/AppBundle/Twig/AppExtension.php
+++ b/src/AppBundle/Twig/AppExtension.php
@@ -49,9 +49,9 @@ class AppExtension extends \Twig_Extension
     }
 
     // the name of the Twig extension must be unique in the application. Consider
-    // using 'app.extension' if you only have one Twig extension in your application.
+    // using 'app' if you only have one Twig extension in your application.
     public function getName()
     {
-        return 'app.extension';
+        return 'app';
     }
 }

--- a/src/AppBundle/Twig/LocaleExtension.php
+++ b/src/AppBundle/Twig/LocaleExtension.php
@@ -53,6 +53,6 @@ class LocaleExtension extends \Twig_Extension
     // the name of the Twig extension must be unique in the application
     public function getName()
     {
-        return 'app.locale_extension';
+        return 'app_locale';
     }
 }

--- a/src/AppBundle/Twig/MarkdownExtension.php
+++ b/src/AppBundle/Twig/MarkdownExtension.php
@@ -24,7 +24,7 @@ use AppBundle\Utils\Markdown;
  * @author Ryan Weaver <weaverryan@gmail.com>
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-class AppExtension extends \Twig_Extension
+class MarkdownExtension extends \Twig_Extension
 {
     private $parser;
 
@@ -52,6 +52,6 @@ class AppExtension extends \Twig_Extension
     // using 'app' if you only have one Twig extension in your application.
     public function getName()
     {
-        return 'app';
+        return 'app_markdown';
     }
 }

--- a/src/AppBundle/Twig/SourceCodeExtension.php
+++ b/src/AppBundle/Twig/SourceCodeExtension.php
@@ -120,6 +120,6 @@ class SourceCodeExtension extends \Twig_Extension
     // the name of the Twig extension must be unique in the application
     public function getName()
     {
-        return 'app.source_code_extension';
+        return 'app_source_code';
     }
 }

--- a/src/AppBundle/Twig/SourceCodeExtension.php
+++ b/src/AppBundle/Twig/SourceCodeExtension.php
@@ -15,7 +15,7 @@ namespace AppBundle\Twig;
  * CAUTION: this is an extremely advanced Twig extension. It's used to get the
  * source code of the controller and the template used to render the current
  * page. If you are starting with Symfony, don't look at this code and consider
- * studying instead the code of the src/AppBundle/Twig/AppExtension.php extension.
+ * studying instead the code of the src/AppBundle/Twig/MarkdownExtension.php extension.
  *
  * @author Ryan Weaver <weaverryan@gmail.com>
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>


### PR DESCRIPTION
This fixes #176.