### PR TITLE
feature #191 Add confirmation message before to delete a post

### DIFF
--- a/app/Resources/translations/messages.en.xliff
+++ b/app/Resources/translations/messages.en.xliff
@@ -80,6 +80,10 @@
                 <source>action.delete_post</source>
                 <target>Delete post</target>
             </trans-unit>
+            <trans-unit id="action.delete_post_confirmation">
+                <source>action.delete_post_confirmation</source>
+                <target>Are you sure you want to delete this post?</target>
+            </trans-unit>
             <trans-unit id="action.create_post">
                 <source>action.create_post</source>
                 <target>Create a new post</target>

--- a/app/Resources/translations/messages.es.xliff
+++ b/app/Resources/translations/messages.es.xliff
@@ -84,6 +84,10 @@
                 <source>action.delete_post</source>
                 <target>Borrar artículo</target>
             </trans-unit>
+            <trans-unit id="action.delete_post_confirmation">
+                <source>action.delete_post_confirmation</source>
+                <target>¿Está seguro que quiere eliminar este artículo?</target>
+            </trans-unit>
             <trans-unit id="action.create_post">
                 <source>action.create_post</source>
                 <target>Crear un nuevo artículo</target>
@@ -152,10 +156,6 @@
             <trans-unit id="label.actions">
                 <source>label.actions</source>
                 <target>Acciones</target>
-            </trans-unit>
-            <trans-unit id="action.delete_post_confirmation">
-                <source>action.delete_post_confirmation</source>
-                <target>¿Está seguro que quiere eliminar este artículo?</target>
             </trans-unit>
             <trans-unit id="title.post_new">
                 <source>title.post_new</source>

--- a/app/Resources/translations/messages.es.xliff
+++ b/app/Resources/translations/messages.es.xliff
@@ -153,6 +153,10 @@
                 <source>label.actions</source>
                 <target>Acciones</target>
             </trans-unit>
+            <trans-unit id="action.delete_post_confirmation">
+                <source>action.delete_post_confirmation</source>
+                <target>¿Está seguro que quiere eliminar este artículo?</target>
+            </trans-unit>
             <trans-unit id="title.post_new">
                 <source>title.post_new</source>
                 <target>Nuevo artículo</target>

--- a/app/Resources/views/admin/blog/_form.html.twig
+++ b/app/Resources/views/admin/blog/_form.html.twig
@@ -6,7 +6,7 @@
     {{ form_start(form, { attr: { novalidate: 'novalidate' } }) }}
 #}
 
-{% if show_confirmation_message is defined %}
+{% if show_confirmation_message is defined and show_confirmation_message == true %}
     {% set attr = {'data-confirmation-message': 'action.delete_post_confirmation'|trans} %}
 {% endif %}
 

--- a/app/Resources/views/admin/blog/_form.html.twig
+++ b/app/Resources/views/admin/blog/_form.html.twig
@@ -10,6 +10,9 @@
     {{ form_widget(form) }}
 
     <input type="submit" value="{{ button_label|default('label.create_post'|trans) }}"
+           {% if confirmation_message is defined %}
+               data-toggle="confirmation" data-message="{{ confirmation_message }}"
+           {% endif %}
            class="{{ button_css|default("btn btn-primary") }}" />
 
     {% if include_back_to_home_link is not defined or include_back_to_home_link == true %}

--- a/app/Resources/views/admin/blog/_form.html.twig
+++ b/app/Resources/views/admin/blog/_form.html.twig
@@ -14,9 +14,6 @@
     {{ form_widget(form) }}
 
     <input type="submit" value="{{ button_label|default('label.create_post'|trans) }}"
-           {% if confirmation_message is defined %}
-               data-toggle="confirmation" data-message="{{ confirmation_message }}"
-           {% endif %}
            class="{{ button_css|default("btn btn-primary") }}" />
 
     {% if include_back_to_home_link is not defined or include_back_to_home_link == true %}

--- a/app/Resources/views/admin/blog/_form.html.twig
+++ b/app/Resources/views/admin/blog/_form.html.twig
@@ -6,11 +6,11 @@
     {{ form_start(form, { attr: { novalidate: 'novalidate' } }) }}
 #}
 
-{% if confirmation_message is defined %}
-    {% set attr = {'data-confirmation-message': confirmation_message} %}
+{% if show_confirmation_message is defined %}
+    {% set attr = {'data-confirmation-message': 'action.delete_post_confirmation'|trans} %}
 {% endif %}
 
-{{ form_start(form, {attr: attr|default({})}) }}
+{{ form_start(form, { attr: attr|default({}) }) }}
     {{ form_widget(form) }}
 
     <input type="submit" value="{{ button_label|default('label.create_post'|trans) }}"

--- a/app/Resources/views/admin/blog/_form.html.twig
+++ b/app/Resources/views/admin/blog/_form.html.twig
@@ -6,7 +6,11 @@
     {{ form_start(form, { attr: { novalidate: 'novalidate' } }) }}
 #}
 
-{{ form_start(form) }}
+{% if confirmation_message is defined %}
+    {% set attr = {'data-confirmation-message': confirmation_message} %}
+{% endif %}
+
+{{ form_start(form, {attr: attr|default({})}) }}
     {{ form_widget(form) }}
 
     <input type="submit" value="{{ button_label|default('label.create_post'|trans) }}"

--- a/app/Resources/views/admin/blog/_form.html.twig
+++ b/app/Resources/views/admin/blog/_form.html.twig
@@ -6,7 +6,7 @@
     {{ form_start(form, { attr: { novalidate: 'novalidate' } }) }}
 #}
 
-{% if show_confirmation_message is defined and show_confirmation_message == true %}
+{% if show_confirmation|default(false) %}
     {% set attr = {'data-confirmation-message': 'action.delete_post_confirmation'|trans} %}
 {% endif %}
 
@@ -16,7 +16,7 @@
     <input type="submit" value="{{ button_label|default('label.create_post'|trans) }}"
            class="{{ button_css|default("btn btn-primary") }}" />
 
-    {% if include_back_to_home_link is not defined or include_back_to_home_link == true %}
+    {% if include_back_to_home_link|default(false) %}
         <a href="{{ path('admin_post_index') }}" class="btn btn-link">
             {{ 'action.back_to_list'|trans }}
         </a>

--- a/app/Resources/views/admin/blog/edit.html.twig
+++ b/app/Resources/views/admin/blog/edit.html.twig
@@ -19,7 +19,8 @@
             form: delete_form,
             button_label: 'action.delete_post'|trans,
             button_css: 'btn btn-lg btn-block btn-danger',
-            include_back_to_home_link: false
+            include_back_to_home_link: false,
+            confirmation_message: 'action.delete_post_confirmation'|trans,
         }, with_context = false) }}
     </div>
 

--- a/app/Resources/views/admin/blog/edit.html.twig
+++ b/app/Resources/views/admin/blog/edit.html.twig
@@ -20,7 +20,7 @@
             button_label: 'action.delete_post'|trans,
             button_css: 'btn btn-lg btn-block btn-danger',
             include_back_to_home_link: false,
-            confirmation_message: 'action.delete_post_confirmation'|trans,
+            show_confirmation_message: true,
         }, with_context = false) }}
     </div>
 

--- a/app/Resources/views/admin/blog/edit.html.twig
+++ b/app/Resources/views/admin/blog/edit.html.twig
@@ -10,6 +10,7 @@
     {{ include('admin/blog/_form.html.twig', {
         form: edit_form,
         button_label: 'action.save'|trans,
+        include_back_to_home_link: true,
     }, with_context = false) }}
 {% endblock %}
 
@@ -19,8 +20,7 @@
             form: delete_form,
             button_label: 'action.delete_post'|trans,
             button_css: 'btn btn-lg btn-block btn-danger',
-            include_back_to_home_link: false,
-            show_confirmation_message: true,
+            show_confirmation: true,
         }, with_context = false) }}
     </div>
 

--- a/app/Resources/views/admin/blog/new.html.twig
+++ b/app/Resources/views/admin/blog/new.html.twig
@@ -5,7 +5,9 @@
 {% block main %}
     <h1>{{ 'title.post_new'|trans }}</h1>
 
-    {{ include('admin/blog/_form.html.twig') }}
+    {{ include('admin/blog/_form.html.twig', {
+        include_back_to_home_link: true,
+    }) }}
 {% endblock %}
 
 {% block sidebar %}

--- a/app/Resources/views/admin/blog/show.html.twig
+++ b/app/Resources/views/admin/blog/show.html.twig
@@ -39,7 +39,8 @@
             form: delete_form,
             button_label: 'action.delete_post'|trans,
             button_css: 'btn btn-lg btn-block btn-danger',
-            include_back_to_home_link: false
+            include_back_to_home_link: false,
+            confirmation_message: 'action.delete_post_confirmation'|trans,
         }, with_context = false) }}
     </div>
 

--- a/app/Resources/views/admin/blog/show.html.twig
+++ b/app/Resources/views/admin/blog/show.html.twig
@@ -39,8 +39,7 @@
             form: delete_form,
             button_label: 'action.delete_post'|trans,
             button_css: 'btn btn-lg btn-block btn-danger',
-            include_back_to_home_link: false,
-            show_confirmation_message: true,
+            show_confirmation: true,
         }, with_context = false) }}
     </div>
 

--- a/app/Resources/views/admin/blog/show.html.twig
+++ b/app/Resources/views/admin/blog/show.html.twig
@@ -40,7 +40,7 @@
             button_label: 'action.delete_post'|trans,
             button_css: 'btn btn-lg btn-block btn-danger',
             include_back_to_home_link: false,
-            confirmation_message: 'action.delete_post_confirmation'|trans,
+            show_confirmation_message: true,
         }, with_context = false) }}
     </div>
 

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -158,7 +158,10 @@
                     $('[data-toggle="confirmation"][data-message]').on('click', function (event) {
                         var message = $(this).data('message');
 
-                        return confirm(message) || event.preventDefault();
+                        if (confirm(message) === false) {
+                            //cancel the event
+                            event.preventDefault();
+                        }
                     });
                 });
             </script>

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -155,8 +155,8 @@
                 $(document).ready(function() {
                     hljs.initHighlightingOnLoad();
 
-                    $('[data-toggle="confirmation"][data-message]').on('click', function (event) {
-                        var message = $(this).data('message');
+                    $('form[data-confirmation-message]').on('submit', function (event) {
+                        var message = $(this).data('confirmation-message');
 
                         if (confirm(message) === false) {
                             //cancel the event

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -155,7 +155,7 @@
                 $(document).ready(function() {
                     hljs.initHighlightingOnLoad();
 
-                    $('form[data-confirmation-message]').on('submit', function (event) {
+                    $('body').on('submit', 'form[data-confirmation-message]', function (event) {
                         var message = $(this).data('confirmation-message');
 
                         if (confirm(message) === false) {

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -154,15 +154,15 @@
             <script>
                 $(document).ready(function() {
                     hljs.initHighlightingOnLoad();
+                });
 
-                    $('body').on('submit', 'form[data-confirmation-message]', function (event) {
-                        var message = $(this).data('confirmation-message');
+                $(document).on('submit', 'form[data-confirmation-message]', function (event) {
+                    var message = $(this).data('confirmation-message');
 
-                        if (confirm(message) === false) {
-                            //cancel the event
-                            event.preventDefault();
-                        }
-                    });
+                    if (confirm(message) === false) {
+                        //cancel the event
+                        event.preventDefault();
+                    }
                 });
             </script>
         {% endblock %}

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -154,6 +154,12 @@
             <script>
                 $(document).ready(function() {
                     hljs.initHighlightingOnLoad();
+
+                    $('[data-toggle="confirmation"][data-message]').on('click', function (event) {
+                        var message = $(this).data('message');
+
+                        return confirm(message) || event.preventDefault();
+                    });
                 });
             </script>
         {% endblock %}


### PR DESCRIPTION
The confirmation dialog is meant to ensure that a user intends to perform an action. This is often done in cases where actions cannot be undone (such as deleting something) or when something substantial will happen (like sending email updates, perhaps).

The user will be responsible for choosing "accept" or "cancel" and the action will not be taken if they choose the latter. You can also use the confirmation dialog to give users any important message before they make their decision.

Fixed #191 