### PR TITLE
Update the way to retrieve the template source

### DIFF
--- a/src/CodeExplorerBundle/EventListener/ControllerListener.php
+++ b/src/CodeExplorerBundle/EventListener/ControllerListener.php
@@ -28,10 +28,7 @@ use CodeExplorerBundle\Twig\SourceCodeExtension;
  */
 class ControllerListener
 {
-    /**
-     * @var SourceCodeExtension
-     */
-    protected $twigExtension;
+    private $twigExtension;
 
     public function __construct(SourceCodeExtension $twigExtension)
     {

--- a/src/CodeExplorerBundle/Resources/config/services.yml
+++ b/src/CodeExplorerBundle/Resources/config/services.yml
@@ -2,7 +2,7 @@ services:
     code_explorer.twig.source_code_extension:
         public:    false
         class:     CodeExplorerBundle\Twig\SourceCodeExtension
-        arguments: [@twig.loader, %kernel.root_dir%]
+        arguments: [%kernel.root_dir%]
         tags:
             - { name: twig.extension }
 

--- a/src/CodeExplorerBundle/Twig/SourceCodeExtension.php
+++ b/src/CodeExplorerBundle/Twig/SourceCodeExtension.php
@@ -22,14 +22,12 @@ namespace CodeExplorerBundle\Twig;
  */
 class SourceCodeExtension extends \Twig_Extension
 {
-    protected $loader;
-    protected $controller;
-    protected $kernelRootDir;
+    private $controller;
+    private $kernelRootDir;
 
-    public function __construct(\Twig_LoaderInterface $loader, $kernelRootDir)
+    public function __construct($kernelRootDir)
     {
         $this->kernelRootDir = $kernelRootDir;
-        $this->loader = $loader;
     }
 
     public function setController($controller)
@@ -101,12 +99,10 @@ class SourceCodeExtension extends \Twig_Extension
 
     private function getTemplateSource(\Twig_Template $template)
     {
-        $templateName = $template->getTemplateName();
-
         return array(
-            'file_path' => $this->kernelRootDir.'/Resources/views/'.$templateName,
+            'file_path' => $this->kernelRootDir.'/Resources/views/'.$template->getTemplateName(),
             'starting_line' => 1,
-            'source_code' => $this->loader->getSource($templateName),
+            'source_code' => $template->getSource(),
         );
     }
 


### PR DESCRIPTION
Latest Twig versions allow to get the source from the Twig_Template object itself, making it work with any loader (and without needing the loader).

I also switched to private visibility in the CodeExplorerBundle according to the coding standards.