### PR TITLE
Add a comment describing the code explorer shortcoming

### DIFF
--- a/src/CodeExplorerBundle/Twig/SourceCodeExtension.php
+++ b/src/CodeExplorerBundle/Twig/SourceCodeExtension.php
@@ -100,6 +100,11 @@ class SourceCodeExtension extends \Twig_Extension
     private function getTemplateSource(\Twig_Template $template)
     {
         return array(
+            // Twig templates are not always stored in files, and so there is no
+            // API to get the filename from a template name in a generic way.
+            // The logic used here works only for templates stored in app/Resources/views
+            // and referenced via the "filename.html.twig" notation, not via the "::filename.html.twig"
+            // one or stored in bundles. This is enough for the needs of the demo app.
             'file_path' => $this->kernelRootDir.'/Resources/views/'.$template->getTemplateName(),
             'starting_line' => 1,
             'source_code' => $template->getSource(),


### PR DESCRIPTION
The goal is to avoid letting people think that this is the generic way to access the file storing a template, because it is not.