### PR TITLE
Add all translatable strings in the English translation file

### DIFF
--- a/app/Resources/translations/messages.en.xliff
+++ b/app/Resources/translations/messages.en.xliff
@@ -18,6 +18,14 @@
                 <source>mit_license</source>
                 <target>MIT License</target>
             </trans-unit>
+            <trans-unit id="previous">
+                <source>Previous</source>
+                <target>Previous</target>
+            </trans-unit>
+            <trans-unit id="next">
+                <source>Next</source>
+                <target>Next</target>
+            </trans-unit>
 
             <trans-unit id="title.homepage">
                 <source>title.homepage</source>


### PR DESCRIPTION
This way, the English translation file can be used as a reference to
find missing translations in all other languages.