### PR TITLE
Include asset Twig function for Symfony 3

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -45,6 +45,7 @@ framework:
         handler_id:  ~
     fragments:       ~
     http_method_override: true
+    assets: ~
 
 # Twig Configuration (used for rendering application templates)
 twig:


### PR DESCRIPTION
Fix next error after update to the Symfony 3:

> Unknown "asset" function in twig template

P.S. following [v3.0.0-BETA1](https://github.com/symfony/symfony-standard/blob/51ca575c8f1339e62edb077f4f5e0ff1f5566423/app/config/config.yml#L34) release