### PR TITLE
Show a template's source code without relying to the "_self" variable

### DIFF
--- a/app/Resources/TwigBundle/views/Exception/error.html.twig
+++ b/app/Resources/TwigBundle/views/Exception/error.html.twig
@@ -28,5 +28,5 @@
 {% block sidebar %}
     {{ parent() }}
 
-    {{ show_source_code(_self) }}
+    {{ show_source_code() }}
 {% endblock %}

--- a/app/Resources/TwigBundle/views/Exception/error403.html.twig
+++ b/app/Resources/TwigBundle/views/Exception/error403.html.twig
@@ -27,5 +27,5 @@
 {% block sidebar %}
     {{ parent() }}
 
-    {{ show_source_code(_self) }}
+    {{ show_source_code() }}
 {% endblock %}

--- a/app/Resources/TwigBundle/views/Exception/error404.html.twig
+++ b/app/Resources/TwigBundle/views/Exception/error404.html.twig
@@ -27,5 +27,5 @@
 {% block sidebar %}
     {{ parent() }}
 
-    {{ show_source_code(_self) }}
+    {{ show_source_code() }}
 {% endblock %}

--- a/app/Resources/TwigBundle/views/Exception/error500.html.twig
+++ b/app/Resources/TwigBundle/views/Exception/error500.html.twig
@@ -27,5 +27,5 @@
 {% block sidebar %}
     {{ parent() }}
 
-    {{ show_source_code(_self) }}
+    {{ show_source_code() }}
 {% endblock %}

--- a/app/Resources/views/admin/blog/edit.html.twig
+++ b/app/Resources/views/admin/blog/edit.html.twig
@@ -26,5 +26,5 @@
 
     {{ parent() }}
 
-    {{ show_source_code(_self) }}
+    {{ show_source_code() }}
 {% endblock %}

--- a/app/Resources/views/admin/blog/index.html.twig
+++ b/app/Resources/views/admin/blog/index.html.twig
@@ -52,5 +52,5 @@
 
     {{ parent() }}
 
-    {{ show_source_code(_self) }}
+    {{ show_source_code() }}
 {% endblock %}

--- a/app/Resources/views/admin/blog/new.html.twig
+++ b/app/Resources/views/admin/blog/new.html.twig
@@ -25,5 +25,5 @@
 {% block sidebar %}
     {{ parent() }}
 
-    {{ show_source_code(_self) }}
+    {{ show_source_code() }}
 {% endblock %}

--- a/app/Resources/views/admin/blog/show.html.twig
+++ b/app/Resources/views/admin/blog/show.html.twig
@@ -43,5 +43,5 @@
         }, with_context = false) }}
     </div>
 
-    {{ show_source_code(_self) }}
+    {{ show_source_code() }}
 {% endblock %}

--- a/app/Resources/views/blog/index.html.twig
+++ b/app/Resources/views/blog/index.html.twig
@@ -25,5 +25,5 @@
 {% block sidebar %}
     {{ parent() }}
 
-    {{ show_source_code(_self) }}
+    {{ show_source_code() }}
 {% endblock %}

--- a/app/Resources/views/blog/post_show.html.twig
+++ b/app/Resources/views/blog/post_show.html.twig
@@ -59,5 +59,5 @@
       to share common contents in different templates #}
     {{ parent() }}
 
-    {{ show_source_code(_self) }}
+    {{ show_source_code() }}
 {% endblock %}

--- a/app/Resources/views/security/login.html.twig
+++ b/app/Resources/views/security/login.html.twig
@@ -84,7 +84,7 @@
 
     {{ parent() }}
 
-    {{ show_source_code(_self) }}
+    {{ show_source_code() }}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/CodeExplorerBundle/Twig/Node/TemplateAwareFunction.php
+++ b/src/CodeExplorerBundle/Twig/Node/TemplateAwareFunction.php
@@ -21,6 +21,6 @@ class TemplateAwareFunction extends \Twig_Node_Expression_Function
      */
     protected function compileArguments(\Twig_Compiler $compiler)
     {
-        $compiler->raw('($this)');
+        $compiler->raw('($this, $this->env)');
     }
 }

--- a/src/CodeExplorerBundle/Twig/Node/TemplateAwareFunction.php
+++ b/src/CodeExplorerBundle/Twig/Node/TemplateAwareFunction.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CodeExplorerBundle\Twig\Node;
+
+/**
+ * @author Oleg Voronkovich <oleg-voronkovich@yandex.ru>
+ */
+class TemplateAwareFunction extends \Twig_Node_Expression_Function
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function compileArguments(\Twig_Compiler $compiler)
+    {
+        $compiler->raw('($this)');
+    }
+}

--- a/src/CodeExplorerBundle/Twig/Node/TemplateAwareFunction.php
+++ b/src/CodeExplorerBundle/Twig/Node/TemplateAwareFunction.php
@@ -21,6 +21,17 @@ class TemplateAwareFunction extends \Twig_Node_Expression_Function
      */
     protected function compileArguments(\Twig_Compiler $compiler)
     {
-        $compiler->raw('($this, $this->env)');
+        $subCompiler = new \Twig_Compiler($compiler->getEnvironment());
+
+        parent::compileArguments($subCompiler);
+
+        $source = $subCompiler->getSource();
+
+        // Pass a template instance as the first argument
+        if ('()' === $source) {
+            $compiler->raw('($this)');
+        } else {
+            $compiler->raw(sprintf('($this, %s', substr($source, 1)));
+        }
     }
 }

--- a/src/CodeExplorerBundle/Twig/SourceCodeExtension.php
+++ b/src/CodeExplorerBundle/Twig/SourceCodeExtension.php
@@ -41,13 +41,16 @@ class SourceCodeExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFunction('show_source_code', array($this, 'showSourceCode'), array('is_safe' => array('html'), 'needs_environment' => true)),
+            new \Twig_SimpleFunction('show_source_code', array($this, 'showSourceCode'), array(
+                'is_safe' => array('html'),
+                'node_class' => 'CodeExplorerBundle\Twig\Node\TemplateAwareFunction'
+            )),
         );
     }
 
-    public function showSourceCode(\Twig_Environment $twig, \Twig_Template $template)
+    public function showSourceCode(\Twig_Template $template)
     {
-        return $twig->render('@CodeExplorer/source_code.html.twig', array(
+        return $template->getEnvironment()->render('@CodeExplorer/source_code.html.twig', array(
             'controller' => $this->getController(),
             'template'   => $this->getTemplateSource($template),
         ));

--- a/src/CodeExplorerBundle/Twig/SourceCodeExtension.php
+++ b/src/CodeExplorerBundle/Twig/SourceCodeExtension.php
@@ -48,9 +48,9 @@ class SourceCodeExtension extends \Twig_Extension
         );
     }
 
-    public function showSourceCode(\Twig_Template $template)
+    public function showSourceCode(\Twig_Template $template, \Twig_Environment $twig)
     {
-        return $template->getEnvironment()->render('@CodeExplorer/source_code.html.twig', array(
+        return $twig->render('@CodeExplorer/source_code.html.twig', array(
             'controller' => $this->getController(),
             'template'   => $this->getTemplateSource($template),
         ));

--- a/src/CodeExplorerBundle/Twig/SourceCodeExtension.php
+++ b/src/CodeExplorerBundle/Twig/SourceCodeExtension.php
@@ -43,7 +43,8 @@ class SourceCodeExtension extends \Twig_Extension
         return array(
             new \Twig_SimpleFunction('show_source_code', array($this, 'showSourceCode'), array(
                 'is_safe' => array('html'),
-                'node_class' => 'CodeExplorerBundle\Twig\Node\TemplateAwareFunction'
+                'needs_environment' => true,
+                'node_class' => 'CodeExplorerBundle\Twig\Node\TemplateAwareFunction',
             )),
         );
     }


### PR DESCRIPTION
Not so professional as https://github.com/symfony/symfony-demo/pull/249 :)