### PR TITLE
Add missing Ukrainian translation

### DIFF
--- a/app/Resources/translations/messages.uk.xliff
+++ b/app/Resources/translations/messages.uk.xliff
@@ -112,6 +112,10 @@
                 <source>label.create_post</source>
                 <target>Створити запис</target>
             </trans-unit>
+            <trans-unit id="label.save_and_create_new">
+                <source>label.save_and_create_new</source>
+                <target>Зберегти та створити новий</target>
+            </trans-unit>
             <trans-unit id="action.back_to_list">
                 <source>action.back_to_list</source>
                 <target>Назад до списку записів</target>


### PR DESCRIPTION
Add missing `label.save_and_create_new` for Ukrainian translation