### PR TITLE
Fix invalid translation key for label name

### DIFF
--- a/app/Resources/views/admin/blog/new.html.twig
+++ b/app/Resources/views/admin/blog/new.html.twig
@@ -14,7 +14,7 @@
 
         <input type="submit" value="{{ 'label.create_post'|trans }}" class="btn btn-primary" />
 
-        {{ form_widget(form.saveAndCreateNew, { label: 'label.save_and_create_new'|trans, attr: { class: 'btn btn-primary' } }) }}
+        {{ form_widget(form.saveAndCreateNew, { label: 'label.save_and_create_new', attr: { class: 'btn btn-primary' } }) }}
 
         <a href="{{ path('admin_post_index') }}" class="btn btn-link">
             {{ 'action.back_to_list'|trans }}


### PR DESCRIPTION
We don't need to translate form labels, it happens automatically - otherwise we get a "Missing messages" notice in debug toolbar.