### PR TITLE
Use csrf_token_generator instead of deprecated csrf_provider

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -31,7 +31,7 @@ security:
                 login_path: security_login_form
                 # Secure the login form against CSRF
                 # Reference: http://symfony.com/doc/current/cookbook/security/csrf_in_login_form.html
-                csrf_provider: security.csrf.token_manager
+                csrf_token_generator: security.csrf.token_manager
 
             logout:
                 # The route name the user can go to in order to logout


### PR DESCRIPTION
The `csrf_provider` on a security firewall has been deprecated in favor of `csrf_token_generator` in 2.8 (https://github.com/symfony/symfony/pull/9587).