### PR TITLE
Remove locale duplicates in array of locales

### DIFF
--- a/src/AppBundle/EventListener/RedirectToPreferredLocaleListener.php
+++ b/src/AppBundle/EventListener/RedirectToPreferredLocaleListener.php
@@ -68,6 +68,7 @@ class RedirectToPreferredLocaleListener
         // because Symfony\HttpFoundation\Request::getPreferredLanguage
         // returns the first element when no an appropriate language is found
         array_unshift($this->locales, $this->defaultLocale);
+        $this->locales = array_unique($this->locales);
     }
 
     /**


### PR DESCRIPTION
We have locale dublicates after default locale unshifted to the array of locales on [line 70](https://github.com/symfony/symfony-demo/blob/master/src/AppBundle/EventListener/RedirectToPreferredLocaleListener.php#L70).