### PR TITLE
Ignore requests from referrers with the same HTTP host

### DIFF
--- a/src/AppBundle/EventListener/RedirectToPreferredLocaleListener.php
+++ b/src/AppBundle/EventListener/RedirectToPreferredLocaleListener.php
@@ -81,6 +81,11 @@ class RedirectToPreferredLocaleListener
         if (!$event->isMasterRequest() || '/' !== $request->getPathInfo()) {
             return;
         }
+        // Ignore requests from referrers with the same HTTP host in order to prevent
+        // changing language for users who possibly already selected it for this application.
+        if (0 === stripos($request->headers->get('referer'), $request->getSchemeAndHttpHost())) {
+            return;
+        }
 
         $preferredLanguage = $request->getPreferredLanguage($this->locales);
 


### PR DESCRIPTION
If user select `en` language and then go to the homepage - language changing to the preferred language base on user's browser suggestion (see `RedirectToPreferredLocaleListener`). But users don't need this because they already selected `en` for this application.

With this PR I suggest to prevent changing language to the preferred language for referrer requests with the same HTTP host. Thus locale changing will be occured only for `homepage`'s direct requests (`HTTP_REFERER` equal to `null`) or requests from referrers with different HTTP hosts in HTTP_REFERER URL.