### PR TITLE
Translate customized error pages

### DIFF
--- a/app/Resources/TwigBundle/views/Exception/error.html.twig
+++ b/app/Resources/TwigBundle/views/Exception/error.html.twig
@@ -13,15 +13,13 @@
 {% block body_id 'error' %}
 
 {% block main %}
-    <h1 class="text-danger">Error</h1>
+    <h1 class="text-danger">{{ 'http_error.name'|trans({ '%status_code%': status_code }) }}</h1>
 
     <p class="lead">
-        There was an unknown error (HTTP {{ status_code }})
-        that prevented to complete your request.
+        {{ 'http_error.description'|trans({ '%status_code%': status_code }) }}
     </p>
     <p>
-        Try loading this page again in some minutes or
-        <a href="{{ path('blog_index') }}">go back to the homepage</a>.
+        {{ 'http_error.suggestion'|trans({ '%url%': path('blog_index') })|raw }}
     </p>
 {% endblock %}
 

--- a/app/Resources/TwigBundle/views/Exception/error403.html.twig
+++ b/app/Resources/TwigBundle/views/Exception/error403.html.twig
@@ -13,14 +13,13 @@
 {% block body_id 'error' %}
 
 {% block main %}
-    <h1 class="text-danger"><i class="fa fa-unlock-alt"></i> Error 403</h1>
+    <h1 class="text-danger"><i class="fa fa-unlock-alt"></i> {{ 'http_error.name'|trans({ '%status_code%': 403 }) }}</h1>
 
     <p class="lead">
-        You don't have permission to access to this resource.
+        {{ 'http_error_403.description'|trans }}
     </p>
     <p>
-        Ask your manager or system administrator to grant you
-        access to this resource.
+        {{ 'http_error_403.suggestion'|trans }}
     </p>
 {% endblock %}
 

--- a/app/Resources/TwigBundle/views/Exception/error404.html.twig
+++ b/app/Resources/TwigBundle/views/Exception/error404.html.twig
@@ -13,14 +13,13 @@
 {% block body_id 'error' %}
 
 {% block main %}
-    <h1 class="text-danger">Error 404</h1>
+    <h1 class="text-danger">{{ 'http_error.name'|trans({ '%status_code%': 404 }) }}</h1>
 
     <p class="lead">
-        We couldn't find the page you requested.
+        {{ 'http_error_404.description'|trans }}
     </p>
     <p>
-        Check out any misspelling in the URL or
-        <a href="{{ path('blog_index') }}">go back to the homepage</a>.
+        {{ 'http_error_404.suggestion'|trans({ '%url%': path('blog_index') })|raw }}
     </p>
 {% endblock %}
 

--- a/app/Resources/TwigBundle/views/Exception/error500.html.twig
+++ b/app/Resources/TwigBundle/views/Exception/error500.html.twig
@@ -13,14 +13,13 @@
 {% block body_id 'error' %}
 
 {% block main %}
-    <h1 class="text-danger">Error 500</h1>
+    <h1 class="text-danger">{{ 'http_error.name'|trans({ '%status_code%': 500 }) }}</h1>
 
     <p class="lead">
-        There was an internal server error.
+        {{ 'http_error_500.description'|trans }}
     </p>
     <p>
-        Try loading this page again in some minutes or
-        <a href="{{ path('blog_index') }}">go back to the homepage</a>.
+        {{ 'http_error_500.suggestion'|trans({ '%url%': path('blog_index') })|raw }}
     </p>
 {% endblock %}
 

--- a/app/Resources/translations/messages.en.xliff
+++ b/app/Resources/translations/messages.en.xliff
@@ -27,6 +27,43 @@
                 <target>Next</target>
             </trans-unit>
 
+            <trans-unit id="http_error.name">
+                <source>http_error.name</source>
+                <target>Error %status_code%</target>
+            </trans-unit>
+            <trans-unit id="http_error.description">
+                <source>http_error.description</source>
+                <target>There was an unknown error (HTTP %status_code%) that prevented to complete your request.</target>
+            </trans-unit>
+            <trans-unit id="http_error.suggestion">
+                <source>http_error.suggestion</source>
+                <target><![CDATA[Try loading this page again in some minutes or <a href="%url%">go back to the homepage</a>.]]></target>
+            </trans-unit>
+            <trans-unit id="http_error_403.description">
+                <source>http_error_403.description</source>
+                <target>You don't have permission to access to this resource.</target>
+            </trans-unit>
+            <trans-unit id="http_error_403.suggestion">
+                <source>http_error_403.suggestion</source>
+                <target>Ask your manager or system administrator to grant you access to this resource.</target>
+            </trans-unit>
+            <trans-unit id="http_error_404.description">
+                <source>http_error_404.description</source>
+                <target>We couldn't find the page you requested.</target>
+            </trans-unit>
+            <trans-unit id="http_error_404.suggestion">
+                <source>http_error_404.suggestion</source>
+                <target><![CDATA[Check out any misspelling in the URL or <a href="%url%">go back to the homepage</a>.]]></target>
+            </trans-unit>
+            <trans-unit id="http_error_500.description">
+                <source>http_error_500.description</source>
+                <target>There was an internal server error.</target>
+            </trans-unit>
+            <trans-unit id="http_error_500.suggestion">
+                <source>http_error_500.suggestion</source>
+                <target><![CDATA[Try loading this page again in some minutes or <a href="%url%">go back to the homepage</a>.]]></target>
+            </trans-unit>
+
             <trans-unit id="title.homepage">
                 <source>title.homepage</source>
                 <target><![CDATA[Welcome to the <strong>Symfony Demo</strong> application]]></target>

--- a/app/config/routing_dev.yml
+++ b/app/config/routing_dev.yml
@@ -6,5 +6,9 @@ _profiler:
     resource: "@WebProfilerBundle/Resources/config/routing/profiler.xml"
     prefix:   /_profiler
 
+_errors:
+    resource: "@TwigBundle/Resources/config/routing/errors.xml"
+    prefix:   /_error
+
 _main:
     resource: routing.yml


### PR DESCRIPTION
We have a translations in this demo app, but error pages do not translate.

For example, when I get some non-existent blog post (`/uk/blog/posts/non-existent-post`) in another lang (except `en`) I should see translated text.