### PR TITLE
Add ability to test HTTP error pages with different locales

### DIFF
--- a/app/config/routing_dev.yml
+++ b/app/config/routing_dev.yml
@@ -9,12 +9,16 @@ _profiler:
     prefix:   /_profiler
 
 # this imports the route used to test error pages. Just browse the following URL:
-# /_error/{status_code}/{format}
-# (e.g. /_error/404, /_error/403.json, /_error/500.xml)
+# /{_locale}/_error/{status_code}/{format}
+# (e.g. /en/_error/404, /en/_error/403.json, /fr/_error/500.xml)
 # See http://symfony.com/doc/current/cookbook/controller/error_pages.html#testing-error-pages-during-development
 _errors:
     resource: "@TwigBundle/Resources/config/routing/errors.xml"
-    prefix:   /_error
+    prefix:   /{_locale}/_error
+    requirements:
+        _locale: %app_locales%
+    defaults:
+        _locale: %locale%
 
 # this loads the main routing file, which usually defines the routes available
 # in any environment (production, development, etc.)


### PR DESCRIPTION
What about to add `_locale` parameter in HTTP error route prefix in order to test HTTP error pages with different locales?