### PR TITLE
Heroku Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Symfony Demo Application
 The "Symfony Demo Application" is a reference application created to show how
 to develop Symfony applications following the recommended best practices.
 
-[![Build Status](https://travis-ci.org/symfony/symfony-demo.svg?branch=master)](https://travis-ci.org/symfony/symfony-demo)
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy) [![Build Status](https://travis-ci.org/symfony/symfony-demo.svg?branch=master)](https://travis-ci.org/symfony/symfony-demo)
 
 Requirements
 ------------

--- a/app.json
+++ b/app.json
@@ -1,0 +1,26 @@
+{
+    "name": "Symfony Demo Application",
+    "description": "The official demo application for the Symfony framework.",
+    "keywords": [
+        "php",
+        "symfony"
+    ],
+    "website": "https://symfony.com/download",
+    "repository": "https://github.com/symfony/symfony-demo",
+    "logo": "https://symfony.com/images/v5/pictos/demoapp.svg?v=4",
+    "success_url": "/",
+    "scripts": {
+        "postdeploy": "php app/console doctrine:schema:create && php app/console doctrine:fixtures:load -n"
+    },
+    "env": {
+        "SYMFONY_ENV": "prod",
+        "SYMFONY_SECRET": {
+            "description": "Extra entropy for %kernel.secret%; used for CSRF tokens, cookies and signed URLs.",
+            "generator": "secret"
+        }
+    },
+    "addons": [
+        "heroku-postgresql"
+    ],
+    "image": "heroku/php"
+}

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -23,6 +23,7 @@ class AppKernel extends Kernel
             new Knp\Bundle\PaginatorBundle\KnpPaginatorBundle(),
             new CodeExplorerBundle\CodeExplorerBundle(),
             new AppBundle\AppBundle(),
+            new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle(),
         );
 
         // Some bundles are only used while developing the application or during
@@ -34,7 +35,6 @@ class AppKernel extends Kernel
             $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
             $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
             $bundles[] = new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle();
-            $bundles[] = new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle();
         }
 
         return $bundles;

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -77,16 +77,7 @@ doctrine:
         # them from the app/config/parameters.yml file. The reason is that config.yml
         # stores options that change the application behavior and parameters.yml
         # stores options that change from one server to another
-        driver:   "%database_driver%"
-        host:     "%database_host%"
-        port:     "%database_port%"
-        dbname:   "%database_name%"
-        user:     "%database_user%"
-        password: "%database_password%"
-        charset:  UTF8
-        # if using pdo_sqlite as your database driver, add the path in parameters.yml
-        # e.g. database_path: "%kernel.root_dir%/data/data.db3"
-        path:     "%database_path%"
+        url: "%database_url%"
 
     orm:
         auto_generate_proxy_classes: "%kernel.debug%"

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -7,6 +7,11 @@ framework:
         strict_requirements: true
     profiler: { only_exceptions: false }
 
+doctrine:
+    dbal:
+        # temp workaround for https://github.com/doctrine/dbal/issues/1106: define DB path here
+        path: "%kernel.root_dir%/data/blog.sqlite"
+
 web_profiler:
     toolbar: %kernel.debug%
     intercept_redirects: false

--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -19,7 +19,7 @@ monolog:
             handler:      nested
         nested:
             type:  stream
-            path:  "%kernel.logs_dir%/%kernel.environment%.log"
+            path:  "php://stderr"
             level: debug
         console:
             type:  console

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -5,23 +5,12 @@
 parameters:
     # this demo application uses an embedded SQLite database to simplify setup.
     # in a real Symfony application you probably will use a MySQL or PostgreSQL database
-    database_driver:   pdo_sqlite
-    database_host:     127.0.0.1
-    database_port:     ~
-    database_name:     ~
-    database_user:     root
-    database_password: ~
-    # the 'database_path' is only used for SQLite type databases
-    database_path:     '%kernel.root_dir%/data/blog.sqlite'
+    # the path must be relative or else it will not work on Windows
+    database_url:      'sqlite:///%kernel.root_dir%/data/blog.sqlite'
 
-    # Uncomment these lines to use a MySQL database instead of SQLite:
+    # Uncomment this line to use a MySQL database instead of SQLite:
     #
-    # database_driver: pdo_mysql
-    # database_host: 127.0.0.1
-    # database_port: ~
-    # database_name: symfony_demo
-    # database_user: root
-    # database_password: ~
+    # database_url: mysql://root:pass@127.0.0.1:3306/symfony_demo
     #
     # You can even create the database and load the sample data from the command line:
     #

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,11 @@
         "symfony-web-dir": "web",
         "symfony-assets-install": "relative",
         "incenteev-parameters": {
-            "file": "app/config/parameters.yml"
+            "file": "app/config/parameters.yml",
+            "env-map": {
+                "database_url": "DATABASE_URL",
+                "secret": "SYMFONY_SECRET"
+            }
         }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a41f6ba0108ab7b4a352f6ee652fd314",
-    "content-hash": "e252d4da3f275dbbcdff242ed802d185",
+    "hash": "41d575e7bd2fd8f7dc20543cc751e975",
+    "content-hash": "d03660a96f1d5f2f6b6bc93f894b244b",
     "packages": [
         {
             "name": "doctrine/annotations",


### PR DESCRIPTION
- logs to `php://stderr` in prod (sane default IMO, also for other PaaS, Docker etc)
- uses `url` to configure database, which in general makes config simpler too (in prod, it uses `DATABASE_URL` from the env)
- DoctrineFixturesBundle is also needed in prod to populate database with fixtures
- `app.json` and "deploy to Heroku" button take care of the magic (go to https://github.com/dzuelke/symfony-demo/tree/herokubutton and scroll down to see it)

Inclusion on http://symfony.com/download is obviously the next step ;)

Changes reviewed by @stof in December.

Should I also add "manual" deploy instructions to `README` or is that out of scope?