### PR TITLE
Update Composer before dependencies installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ matrix:
   allow_failures:
     - php: hhvm
 
+before_install:
+  - composer self-update
+
 install:
   - composer install
 


### PR DESCRIPTION
Travis use the old Composer's version by default