### PR TITLE
Use non-deprecated APC validator and serializer service names

### DIFF
--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -3,7 +3,9 @@ imports:
 
 #framework:
 #    validation:
-#        cache: apc
+#        cache: validator.mapping.cache.doctrine.apc
+#    serializer:
+#        cache: serializer.mapping.cache.doctrine.apc
 
 #doctrine:
 #    orm:


### PR DESCRIPTION
According to the https://github.com/symfony/symfony-standard/pull/901 .