### PR TITLE
Wrap MySQL config URL with single quotes

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -10,7 +10,7 @@ parameters:
 
     # Uncomment this line to use a MySQL database instead of SQLite:
     #
-    # database_url: mysql://root:pass@127.0.0.1:3306/symfony_demo
+    # database_url:      'mysql://root:pass@127.0.0.1:3306/symfony_demo'
     #
     # You can even create the database and load the sample data from the command line:
     #


### PR DESCRIPTION
Quotes allows avoiding YAML's syntax error after uncommenting.
