### PR TITLE
Fix minor flash handling

### DIFF
--- a/app/Resources/views/admin/blog/edit.html.twig
+++ b/app/Resources/views/admin/blog/edit.html.twig
@@ -5,8 +5,6 @@
 {% block main %}
     <h1>{{ 'title.edit_post'|trans({'%id%': post.id}) }}</h1>
 
-    {{ include('default/_flash_messages.html.twig') }}
-
     {{ include('admin/blog/_form.html.twig', {
         form: edit_form,
         button_label: 'action.save'|trans,

--- a/app/Resources/views/default/_flash_messages.html.twig
+++ b/app/Resources/views/default/_flash_messages.html.twig
@@ -7,7 +7,7 @@
    '_flash_messages.html.twig' instead of 'flash_messages.html.twig'
 #}
 
-{% if app.session.started %}
+{% if app.session.started and app.session.flashBag.has('success') %}
     <div class="messages">
         {% for message in app.session.flashBag.get('success') %}
             {# Bootstrap alert, see http://getbootstrap.com/components/#alerts #}


### PR DESCRIPTION
This PR remove the useless flash partial include in `edit.html.twig` (as it is already included in `base.html.twig`).

I tweaked the flash partial a little to output `<div class="messages">` only if there is really something to display in the flashbag.

