### PR TITLE
Fix incorrect 404 response

### DIFF
--- a/src/AppBundle/Controller/BlogController.php
+++ b/src/AppBundle/Controller/BlogController.php
@@ -46,7 +46,7 @@ class BlogController extends Controller
         $posts = $paginator->paginate($query, $page, Post::NUM_ITEMS);
         $posts->setUsedRoute('blog_index_paginated');
 
-        if (0 === count($posts)) {
+        if (0 === count($posts) && 1 < $page) {
             throw $this->createNotFoundException();
         }
 


### PR DESCRIPTION
On the public section, when there are no posts and we are on page 1 we should not return a 404 response.

In fact, that case is already handled in the view.