### PR TITLE
Iterate over all flash messages in bag

### DIFF
--- a/app/Resources/views/default/_flash_messages.html.twig
+++ b/app/Resources/views/default/_flash_messages.html.twig
@@ -7,17 +7,19 @@
    '_flash_messages.html.twig' instead of 'flash_messages.html.twig'
 #}
 
-{% if app.session.started and app.session.flashBag.has('success') %}
+{% if app.session.started and app.session.flashBag.peekAll is not empty %}
     <div class="messages">
-        {% for message in app.session.flashBag.get('success') %}
-            {# Bootstrap alert, see http://getbootstrap.com/components/#alerts #}
-            <div class="alert alert-dismissible alert-success" role="alert">
-                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
+        {% for type, messages in app.session.flashBag.all %}
+            {% for message in messages %}
+                {# Bootstrap alert, see http://getbootstrap.com/components/#alerts #}
+                <div class="alert alert-dismissible alert-{{ type }}" role="alert">
+                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
 
-                {{ message|trans }}
-            </div>
+                    {{ message|trans }}
+                </div>
+            {% endfor %}
         {% endfor %}
     </div>
 {% endif %}


### PR DESCRIPTION
This PR allows iterating over all message types in the flash bag. It discovers an ability to use different alert types which provided out-of-the-box by Bootstrap and even create a custom one with adding our own `alert-*` CSS classes:

![screenshot from 2016-03-31 10-37-54](https://cloud.githubusercontent.com/assets/3317635/14168793/fc7590a6-f72c-11e5-9d29-d9792686d29b.png)

The code behind this is:
```php
class BlogController extends Controller
{
    public function indexAction()
    {
        $this->addFlash('success', 'Success message');
        $this->addFlash('info', 'Info message');
        $this->addFlash('warning', 'Warning message');
        $this->addFlash('danger', 'Danger message');
        // ...
    }
}
```