### PR TITLE
Use cache.adapter.apcu instead of deprecated validator and serializer

### DIFF
--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -2,10 +2,8 @@ imports:
     - { resource: config.yml }
 
 #framework:
-#    validation:
-#        cache: validator.mapping.cache.doctrine.apc
-#    serializer:
-#        cache: serializer.mapping.cache.apc
+#    cache:
+#        system: cache.adapter.apcu
 
 #doctrine:
 #    orm:


### PR DESCRIPTION
According to the https://github.com/symfony/symfony-standard/pull/965