### PR TITLE
Remove "ircmaxell/password-compat" package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         "erusev/parsedown"                     : "^1.5",
         "ezyang/htmlpurifier"                  : "^4.7",
         "incenteev/composer-parameter-handler" : "^2.0",
-        "ircmaxell/password-compat"            : "^1.0",
         "leafo/scssphp"                        : "^0.5",
         "patchwork/jsqueeze"                   : "^2.0",
         "sensio/distribution-bundle"           : "^5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -1023,48 +1023,6 @@
             "time": "2015-11-10 17:04:01"
         },
         {
-            "name": "ircmaxell/password-compat",
-            "version": "v1.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ircmaxell/password_compat.git",
-                "reference": "5c5cde8822a69545767f7c7f3058cb15ff84614c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ircmaxell/password_compat/zipball/5c5cde8822a69545767f7c7f3058cb15ff84614c",
-                "reference": "5c5cde8822a69545767f7c7f3058cb15ff84614c",
-                "shasum": ""
-            },
-            "require-dev": {
-                "phpunit/phpunit": "4.*"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "lib/password.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Anthony Ferrara",
-                    "email": "ircmaxell@php.net",
-                    "homepage": "http://blog.ircmaxell.com"
-                }
-            ],
-            "description": "A compatibility library for the proposed simplified password hashing algorithm: https://wiki.php.net/rfc/password_hash",
-            "homepage": "https://github.com/ircmaxell/password_compat",
-            "keywords": [
-                "hashing",
-                "password"
-            ],
-            "time": "2014-11-20 16:49:30"
-        },
-        {
             "name": "jdorn/sql-formatter",
             "version": "v1.2.17",
             "source": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "26725ea27270d21f470e82fbc5b84138",
-    "content-hash": "232c69ccb84b8d9d4e3943855d2e9afe",
+    "hash": "44a25675a4555856202aff994d036594",
+    "content-hash": "705e36e3576ba45d2d2aa678c320f082",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -2624,7 +2624,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.9",
+        "php": ">=5.5.9",
         "ext-pdo_sqlite": "*"
     },
     "platform-dev": [],


### PR DESCRIPTION
We don't need this package after the switch to PHP 5.5.