### PR TITLE
Fix console path in the comments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,5 +17,5 @@ uncomment the Assetic blocks in the `app/Resources/views/base.html.twig` and
 execute the following command:
 
 ```bash
-$ php app/console assetic:dump --no-debug
+$ php bin/console assetic:dump --no-debug
 ```

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ in your web server to access the application. Just use the built-in web server:
 
 ```bash
 $ cd symfony-demo/
-$ php app/console server:run
+$ php bin/console server:run
 ```
 
 This command will start a web server for the Symfony application. Now you can

--- a/app.json
+++ b/app.json
@@ -10,7 +10,7 @@
     "logo": "https://symfony.com/images/v5/pictos/demoapp.svg?v=4",
     "success_url": "/",
     "scripts": {
-        "postdeploy": "php app/console doctrine:schema:create && php app/console doctrine:fixtures:load -n"
+        "postdeploy": "php bin/console doctrine:schema:create && php bin/console doctrine:fixtures:load -n"
     },
     "env": {
         "SYMFONY_ENV": "prod",

--- a/app/Resources/views/security/login.html.twig
+++ b/app/Resources/views/security/login.html.twig
@@ -66,14 +66,14 @@
                         <span class="label label-success">{{ 'note'|trans }}</span>
                         {{ 'help.reload_fixtures'|trans }}<br/>
 
-                        <code class="console">$ php app/console doctrine:fixtures:load</code>
+                        <code class="console">$ php bin/console doctrine:fixtures:load</code>
                     </p>
 
                     <p>
                         <span class="label label-success">{{ 'tip'|trans }}</span>
                         {{ 'help.add_user'|trans }}<br/>
 
-                        <code class="console">$ php app/console app:add-user</code>
+                        <code class="console">$ php bin/console app:add-user</code>
                     </p>
                 </div>
             </div>

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -17,9 +17,9 @@ parameters:
     # You can even create the database and load the sample data from the command line:
     #
     # $ cd symfony-demo/
-    # $ php app/console doctrine:database:create
-    # $ php app/console doctrine:schema:create
-    # $ php app/console doctrine:fixtures:load
+    # $ php bin/console doctrine:database:create
+    # $ php bin/console doctrine:schema:create
+    # $ php bin/console doctrine:fixtures:load
 
     # If you don't use a real mail server, you can send emails via your Gmail account.
     # see http://symfony.com/doc/current/cookbook/email/gmail.html

--- a/src/AppBundle/Command/AddUserCommand.php
+++ b/src/AppBundle/Command/AddUserCommand.php
@@ -25,11 +25,11 @@ use AppBundle\Entity\User;
  * To use this command, open a terminal window, enter into your project
  * directory and execute the following:
  *
- *     $ php app/console app:add-user
+ *     $ php bin/console app:add-user
  *
  * To output detailed information, increase the command verbosity:
  *
- *     $ php app/console app:add-user -vv
+ *     $ php bin/console app:add-user -vv
  *
  * See http://symfony.com/doc/current/cookbook/console/console_command.html
  *
@@ -103,7 +103,7 @@ class AddUserCommand extends ContainerAwareCommand
             'If you prefer to not use this interactive wizard, provide the',
             'arguments required by this command as follows:',
             '',
-            ' $ php app/console app:add-user username password email@example.com',
+            ' $ php bin/console app:add-user username password email@example.com',
             '',
         ));
 

--- a/src/AppBundle/Command/DeleteUserCommand.php
+++ b/src/AppBundle/Command/DeleteUserCommand.php
@@ -24,7 +24,7 @@ use Doctrine\Common\Persistence\ObjectManager;
  * To use this command, open a terminal window, enter into your project
  * directory and execute the following:
  *
- *     $ php app/console app:delete-user
+ *     $ php bin/console app:delete-user
  *
  * Check out the code of the src/AppBundle/Command/AddUserCommand.php file for
  * the full explanation about Symfony commands.
@@ -83,7 +83,7 @@ HELP
             'If you prefer to not use this interactive wizard, provide the',
             'arguments required by this command as follows:',
             '',
-            ' $ php app/console app:delete-user username',
+            ' $ php bin/console app:delete-user username',
             '',
         ));
 

--- a/src/AppBundle/Command/ListUsersCommand.php
+++ b/src/AppBundle/Command/ListUsersCommand.php
@@ -24,7 +24,7 @@ use Symfony\Component\Console\Output\BufferedOutput;
  * A command console that lists all the existing users. To use this command, open
  * a terminal window, enter into your project directory and execute the following:
  *
- *     $ php app/console app:list-users
+ *     $ php bin/console app:list-users
  *
  * See http://symfony.com/doc/current/cookbook/console/console_command.html
  *

--- a/src/AppBundle/DataFixtures/ORM/LoadFixtures.php
+++ b/src/AppBundle/DataFixtures/ORM/LoadFixtures.php
@@ -23,7 +23,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * Defines the sample data to load in the database when running the unit and
  * functional tests. Execute this command to load the data:
  *
- *   $ php app/console doctrine:fixtures:load
+ *   $ php bin/console doctrine:fixtures:load
  *
  * See http://symfony.com/doc/current/bundles/DoctrineFixturesBundle/index.html
  *


### PR DESCRIPTION
We moved console to the new directory, but forgot about changing it in the comments. This PR fixes it.