### PR TITLE
Use same URL for login form and check

### DIFF
--- a/app/Resources/views/blog/post_show.html.twig
+++ b/app/Resources/views/blog/post_show.html.twig
@@ -18,7 +18,7 @@
             {{ render(controller('AppBundle:Blog:commentForm', { 'id': post.id })) }}
         {% else %}
             <p>
-                <a class="btn btn-success" href="{{ path('security_login_form') }}">
+                <a class="btn btn-success" href="{{ path('security_login') }}">
                     <i class="fa fa-sign-in"></i> {{ 'action.sign_in'|trans }}
                 </a>
                 {{ 'post.to_publish_a_comment'|trans }}

--- a/app/Resources/views/security/login.html.twig
+++ b/app/Resources/views/security/login.html.twig
@@ -12,7 +12,7 @@
     <div class="row">
         <div class="col-sm-5">
             <div class="well">
-                <form action="{{ path('security_login_check') }}" method="post">
+                <form action="{{ path('security_login') }}" method="post">
                     <fieldset>
                         <legend><i class="fa fa-lock"></i> {{ 'title.login'|trans }}</legend>
                         <div class="form-group">

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -25,10 +25,10 @@ security:
             # Reference: http://symfony.com/doc/current/cookbook/security/form_login_setup.html
             form_login:
                 # The route name that the login form submits to
-                check_path: security_login_check
+                check_path: security_login
                 # The name of the route where the login form lives
                 # When the user tries to access a protected page, they are redirected here
-                login_path: security_login_form
+                login_path: security_login
                 # Secure the login form against CSRF
                 # Reference: http://symfony.com/doc/current/cookbook/security/csrf_in_login_form.html
                 csrf_token_generator: security.csrf.token_manager

--- a/src/AppBundle/Controller/SecurityController.php
+++ b/src/AppBundle/Controller/SecurityController.php
@@ -25,8 +25,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 class SecurityController extends Controller
 {
     /**
-     * @Route("/login", name="security_login_form")
-     * @Method("GET")
+     * @Route("/login", name="security_login")
      */
     public function loginAction()
     {
@@ -38,19 +37,6 @@ class SecurityController extends Controller
             // last authentication error (if any)
             'error' => $helper->getLastAuthenticationError(),
         ));
-    }
-
-    /**
-     * This is the route the login form submits to.
-     *
-     * But, this will never be executed. Symfony will intercept this first
-     * and handle the login automatically. See form_login in app/config/security.yml
-     *
-     * @Route("/login_check", name="security_login_check")
-     */
-    public function loginCheckAction()
-    {
-        throw new \Exception('This should never be reached!');
     }
 
     /**


### PR DESCRIPTION
The Security Form login listener will only intercept the request when it's a POST request, otherwise the controller will be executed. Using the same URL makes things a bit easier, removes the need for the weird controller (which is visited, but should not be executed) and makes things similar to other forms.

Related doc tickets:
 * https://github.com/symfony/symfony-docs/issues/6126
 * https://github.com/symfony/symfony-docs/pull/6143