### PR TITLE
Tweak Symfony blog URL

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -124,7 +124,7 @@
                             <p>
                                 <a href="https://twitter.com/symfony"><i class="fa fa-twitter"></i></a>
                                 <a href="https://www.facebook.com/SensioLabs"><i class="fa fa-facebook"></i></a>
-                                <a href="http://symfony.com/blog"><i class="fa fa-rss"></i></a>
+                                <a href="https://symfony.com/blog/"><i class="fa fa-rss"></i></a>
                             </p>
                         </div>
                     </div>


### PR DESCRIPTION
Use `https` schema and add trailing slash for the Symfony blog URL to prevent extra redirection.