### PR TITLE
Fill default username and password only when it's empty

### DIFF
--- a/app/Resources/views/security/login.html.twig
+++ b/app/Resources/views/security/login.html.twig
@@ -92,8 +92,12 @@
 
     <script>
         $(document).ready(function() {
-            $('#username').val('anna_admin');
-            $('#password').val('kitten');
+            var usernameEl = $('#username');
+            var passwordEl = $('#password');
+            if (!usernameEl.val() && !passwordEl.val()) {
+                usernameEl.val('anna_admin');
+                passwordEl.val('kitten');
+            }
         });
     </script>
 {% endblock %}


### PR DESCRIPTION
We lose `Security::LAST_USERNAME` on authorization failure.