### PR TITLE
Add available locales to the admin path in access control

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -42,4 +42,4 @@ security:
     access_control:
         # this is a catch-all for the admin area
         # additional security lives in the controllers
-        - { path: ^/admin, roles: ROLE_ADMIN }
+        - { path: '^/(%app_locales%)/admin', roles: ROLE_ADMIN }


### PR DESCRIPTION
As I realized, only `@Security` annotation works in admin `BlogController` for now. Actually, we don't have `/admin` URL, all admin pages are prefixed with a locale.