### PR TITLE
Fix Deploying to the Heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,9 +9,6 @@
     "repository": "https://github.com/symfony/symfony-demo",
     "logo": "https://symfony.com/images/v5/pictos/demoapp.svg?v=4",
     "success_url": "/",
-    "scripts": {
-        "postdeploy": "php bin/console doctrine:schema:create && php bin/console doctrine:fixtures:load -n"
-    },
     "env": {
         "SYMFONY_ENV": "prod",
         "SYMFONY_SECRET": {

--- a/app.json
+++ b/app.json
@@ -16,8 +16,5 @@
             "generator": "secret"
         }
     },
-    "addons": [
-        "heroku-postgresql"
-    ],
     "image": "heroku/php"
 }


### PR DESCRIPTION
Fix #371 .

Let's use SQLite DB with pre-populated data instead of bootstrapping a new PostgreSQL one:

It works for me: https://symfony-demo.herokuapp.com