### PR TITLE
Ensure default Post sort order shows newer Posts first

### DIFF
--- a/src/AppBundle/Controller/Admin/BlogController.php
+++ b/src/AppBundle/Controller/Admin/BlogController.php
@@ -54,7 +54,7 @@ class BlogController extends Controller
     public function indexAction()
     {
         $entityManager = $this->getDoctrine()->getManager();
-        $posts = $entityManager->getRepository(Post::class)->findAll();
+        $posts = $entityManager->getRepository(Post::class)->findBy([], ['publishedAt' => 'DESC']);
 
         return $this->render('admin/blog/index.html.twig', ['posts' => $posts]);
     }


### PR DESCRIPTION
In at least #223 the topic of sorting on the **admin backend** was mentioned. This is the first time I've loaded the demo app in quite awhile and wasn't sure it was working because I didn't realize the new post I had added was going to show up at the bottom of the list. It may not be a problem for everyone but the bottom of the list on my laptop was well past the fold.

I appreciate that we do not need to make this **admin backend** fully completed with pagination and column-by-column sorting and what-not. However, I think it would make sense to have newer posts showing up at the top.