### PR TITLE
Update sl translation

### DIFF
--- a/app/Resources/translations/messages.sl.xliff
+++ b/app/Resources/translations/messages.sl.xliff
@@ -219,6 +219,10 @@
                 <source>menu.toggle_nav</source>
                 <target>Preklop navigacije</target>
             </trans-unit>
+            <trans-unit id="menu.choose_language">
+                <source>menu.choose_language</source>
+                <target>Izbira jezika</target>
+            </trans-unit>
             <trans-unit id="menu.post_list">
                 <source>menu.post_list</source>
                 <target>Seznam objav</target>


### PR DESCRIPTION
This patch updates Slovenian (sl_SI) translation according to the English.

Thanks for considering merging it.