### PR TITLE
Minor performance optimizations

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -16,12 +16,13 @@ class AppKernel extends Kernel
             new Symfony\Bundle\SecurityBundle\SecurityBundle(),
             new Symfony\Bundle\TwigBundle\TwigBundle(),
             new Symfony\Bundle\MonologBundle\MonologBundle(),
-            new Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             new WhiteOctober\PagerfantaBundle\WhiteOctoberPagerfantaBundle(),
             new CodeExplorerBundle\CodeExplorerBundle(),
             new AppBundle\AppBundle(),
+            // uncomment the following line if your application sends emails
+            // new Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
         ];
 
         // Some bundles are only used while developing the application or during

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -22,7 +22,6 @@ class AppKernel extends Kernel
             new WhiteOctober\PagerfantaBundle\WhiteOctoberPagerfantaBundle(),
             new CodeExplorerBundle\CodeExplorerBundle(),
             new AppBundle\AppBundle(),
-            new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle(),
         ];
 
         // Some bundles are only used while developing the application or during
@@ -34,6 +33,7 @@ class AppKernel extends Kernel
             $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
             $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
             $bundles[] = new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle();
+            $bundles[] = new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle();
         }
 
         return $bundles;

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -74,9 +74,9 @@ doctrine:
         auto_mapping: true
 
 # Swiftmailer Configuration (used to send emails)
-swiftmailer:
-    transport: "%mailer_transport%"
-    host:      "%mailer_host%"
-    username:  "%mailer_user%"
-    password:  "%mailer_password%"
-    spool:     { type: memory }
+# swiftmailer:
+#     transport: "%mailer_transport%"
+#     host:      "%mailer_host%"
+#     username:  "%mailer_user%"
+#     password:  "%mailer_password%"
+#     spool:     { type: memory }

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -12,8 +12,8 @@ web_profiler:
     toolbar: false
     intercept_redirects: false
 
-swiftmailer:
-    disable_delivery: true
+# swiftmailer:
+#     disable_delivery: true
 
 # It's recommended to use a separate database for tests. This allows to have a
 # fixed and known set of data fixtures, it simplifies the code of tests and it


### PR DESCRIPTION
* The purpose of the Symfony Demo is not to build a fast Symfony app, but to showcase how to develop Symfony apps. However, we should optimize the things that make sense and not complicate the application much.
* We're not sending emails, so we can stop loading the Swift bundle.
* We're promoting Assetic less and less ... so we could stop loading Assetic bundle too. Sadly we can't remove Assetic entirely yet because there is no clear alternative (maybe stop using SCSS and just use some simple CSS and JS files?).