### PR TITLE
Remove obsolete code

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -7,12 +7,6 @@ framework:
         strict_requirements: true
     profiler: { only_exceptions: false }
 
-# remove next 4 lines if you are not using standard SQLite database but e.g. MySQL
-doctrine:
-    dbal:
-        # temp workaround for https://github.com/doctrine/dbal/issues/1106: define DB path here
-        path: "%kernel.root_dir%/data/blog.sqlite"
-
 web_profiler:
     toolbar: '%kernel.debug%'
     intercept_redirects: false


### PR DESCRIPTION
Now that Doctrine DBAL 2.5.5 is out, I think we can remove this "hack". Also because the config value is different from the one recommended and commented in the main config, which might confuse people.