### PR TITLE
Updated to Symfony 3.2 BETA1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "sensio/framework-extra-bundle"        : "^3.0",
         "symfony/monolog-bundle"               : "^2.8",
         "symfony/swiftmailer-bundle"           : "^2.3",
-        "symfony/symfony"                      : "^3.1",
+        "symfony/symfony"                      : "^3.2-beta1",
         "twig/extensions"                      : "^1.3",
         "twig/twig"                            : "^1.25",
         "white-october/pagerfanta-bundle"      : "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "symfony/swiftmailer-bundle"           : "^2.3",
         "symfony/symfony"                      : "^3.2-beta1",
         "twig/extensions"                      : "^1.3",
-        "twig/twig"                            : "^1.25",
+        "twig/twig"                            : "^1.27",
         "white-october/pagerfanta-bundle"      : "^1.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "615d6e456d9690bb674e6d73fab626e2",
-    "content-hash": "1ee28daac4cf7c8d98f0842324ba8bb4",
+    "hash": "dcab3ad6f8670398e973ad35a9d3363e",
+    "content-hash": "06fff9225fbc56ff903173b460273352",
     "packages": [
         {
             "name": "doctrine/annotations",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "71bfbeadf26c2d85c5631f9d19089310",
-    "content-hash": "67d10d8b4e6536105f0d0908910cd143",
+    "hash": "615d6e456d9690bb674e6d73fab626e2",
+    "content-hash": "1ee28daac4cf7c8d98f0842324ba8bb4",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -1973,16 +1973,16 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "v3.1.5",
+            "version": "v3.2.0-BETA1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/symfony.git",
-                "reference": "e7e1d01fe103de78bca6fbf7f6f4acf64482d63c"
+                "reference": "ea699a044f10bff2782b6c0df17f1bf77550adfb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/symfony/zipball/e7e1d01fe103de78bca6fbf7f6f4acf64482d63c",
-                "reference": "e7e1d01fe103de78bca6fbf7f6f4acf64482d63c",
+                "url": "https://api.github.com/repos/symfony/symfony/zipball/ea699a044f10bff2782b6c0df17f1bf77550adfb",
+                "reference": "ea699a044f10bff2782b6c0df17f1bf77550adfb",
                 "shasum": ""
             },
             "require": {
@@ -1995,7 +1995,7 @@
                 "symfony/polyfill-php56": "~1.0",
                 "symfony/polyfill-php70": "~1.0",
                 "symfony/polyfill-util": "~1.0",
-                "twig/twig": "~1.26|~2.0"
+                "twig/twig": "~1.27|~2.0"
             },
             "conflict": {
                 "phpdocumentor/reflection-docblock": "<3.0",
@@ -2050,6 +2050,7 @@
                 "symfony/validator": "self.version",
                 "symfony/var-dumper": "self.version",
                 "symfony/web-profiler-bundle": "self.version",
+                "symfony/workflow": "self.version",
                 "symfony/yaml": "self.version"
             },
             "require-dev": {
@@ -2059,7 +2060,7 @@
                 "doctrine/dbal": "~2.4",
                 "doctrine/doctrine-bundle": "~1.4",
                 "doctrine/orm": "~2.4,>=2.4.5",
-                "egulias/email-validator": "~1.2,>=1.2.1",
+                "egulias/email-validator": "~1.2,>=1.2.8|~2.0",
                 "monolog/monolog": "~1.11",
                 "ocramius/proxy-manager": "~0.4|~1.0|~2.0",
                 "phpdocumentor/reflection-docblock": "^3.0",
@@ -2071,7 +2072,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -2110,7 +2111,7 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2016-10-03 19:01:14"
+            "time": "2016-10-27 03:45:57"
         },
         {
             "name": "twig/extensions",
@@ -2166,16 +2167,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v1.26.1",
+            "version": "v1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "a09d8ee17ac1cfea29ed60c83960ad685c6a898d"
+                "reference": "3c6c0033fd3b5679c6e1cb60f4f9766c2b424d97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/a09d8ee17ac1cfea29ed60c83960ad685c6a898d",
-                "reference": "a09d8ee17ac1cfea29ed60c83960ad685c6a898d",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/3c6c0033fd3b5679c6e1cb60f4f9766c2b424d97",
+                "reference": "3c6c0033fd3b5679c6e1cb60f4f9766c2b424d97",
                 "shasum": ""
             },
             "require": {
@@ -2188,7 +2189,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.26-dev"
+                    "dev-master": "1.27-dev"
                 }
             },
             "autoload": {
@@ -2223,7 +2224,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2016-10-05 18:57:41"
+            "time": "2016-10-25 19:17:17"
         },
         {
             "name": "white-october/pagerfanta-bundle",
@@ -3390,7 +3391,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "symfony/symfony": 10
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/src/CodeExplorerBundle/Twig/SourceCodeExtension.php
+++ b/src/CodeExplorerBundle/Twig/SourceCodeExtension.php
@@ -99,15 +99,16 @@ class SourceCodeExtension extends \Twig_Extension
 
     private function getTemplateSource(\Twig_Template $template)
     {
+        $templateSource = $template->getSourceContext();
+
         return [
-            // Twig templates are not always stored in files, and so there is no
-            // API to get the filename from a template name in a generic way.
-            // The logic used here works only for templates stored in app/Resources/views
-            // and referenced via the "filename.html.twig" notation, not via the "::filename.html.twig"
-            // one or stored in bundles. This is enough for the needs of the demo app.
-            'file_path' => $this->kernelRootDir.'/Resources/views/'.$template->getTemplateName(),
+            // Twig templates are not always stored in files (they can be stored
+            // in a database for example). However, for the needs of the Symfony
+            // Demo app, we consider that all templates are stored in files and
+            // that their file paths can be obtained through the source context.
+            'file_path' => $templateSource->getPath(),
             'starting_line' => 1,
-            'source_code' => $template->getSource(),
+            'source_code' => $templateSource->getCode(),
         ];
     }
 


### PR DESCRIPTION
The beta1 of Symfony 3.2 has just been released, so let's upgrade the Symfony Demo to catch bugs and deprecations before the final release.
