### PR TITLE
Use dynamic env params for critical settings and restore Heroku deploys

### DIFF
--- a/app.json
+++ b/app.json
@@ -14,6 +14,7 @@
     },
     "env": {
         "SYMFONY_ENV": "prod",
+        "SYMFONY_LOG": "php://stderr",
         "SYMFONY_SECRET": {
             "description": "Extra entropy for %kernel.secret%; used for CSRF tokens, cookies and signed URLs.",
             "generator": "secret"

--- a/app.json
+++ b/app.json
@@ -9,6 +9,9 @@
     "repository": "https://github.com/symfony/symfony-demo",
     "logo": "https://symfony.com/images/v5/pictos/demoapp.svg?v=4",
     "success_url": "/",
+    "scripts": {
+        "postdeploy": "php bin/console doctrine:schema:create && php bin/console doctrine:fixtures:load -n"
+    },
     "env": {
         "SYMFONY_ENV": "prod",
         "SYMFONY_SECRET": {
@@ -16,5 +19,8 @@
             "generator": "secret"
         }
     },
+    "addons": [
+        "heroku-postgresql"
+    ],
     "image": "heroku/php"
 }

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -21,6 +21,7 @@ class AppKernel extends Kernel
             new WhiteOctober\PagerfantaBundle\WhiteOctoberPagerfantaBundle(),
             new CodeExplorerBundle\CodeExplorerBundle(),
             new AppBundle\AppBundle(),
+            new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle(), // used for initial population of non-SQLite databases in production envs
             // uncomment the following line if your application sends emails
             // new Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
         ];
@@ -34,7 +35,6 @@ class AppKernel extends Kernel
             $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
             $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
             $bundles[] = new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle();
-            $bundles[] = new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle();
         }
 
         return $bundles;

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -31,7 +31,7 @@ framework:
     # http://symfony.com/doc/current/book/http_cache.html#edge-side-includes
     esi:             { enabled: true }
     translator:      { fallback: "%locale%" }
-    secret:          "%secret%"
+    secret:          "%env(SYMFONY_SECRET)%"
     router:
         resource: "%kernel.root_dir%/config/routing.yml"
         strict_requirements: ~
@@ -61,10 +61,10 @@ twig:
 # Doctrine Configuration (used to access databases and manipulate their information)
 doctrine:
     dbal:
-        # if you don't want to use SQLite, comment the two following lines
-        driver: "pdo_sqlite"
-        path: "%kernel.root_dir%/data/blog.sqlite"
-        # uncomment the following lines to use a database different than SQLite
+        # if you don't want to use SQLite, change the URL in parameters.yml or set the DATABASE_URL environment variable
+        url: "%env(DATABASE_URL)%"
+        
+        # instead of using a URL, you may also uncomment the following lines to configure your database
         # driver:   pdo_mysql
         # host:     "%database_host%"
         # port:     "%database_port%"

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -15,7 +15,7 @@ monolog:
     handlers:
         main:
             type:   stream
-            path:   "%kernel.logs_dir%/%kernel.environment%.log"
+            path:   "%env(SYMFONY_LOG)%"
             level:  info
         console:
             type:   console

--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -19,7 +19,7 @@ monolog:
             handler:      nested
         nested:
             type:  stream
-            path:  "%kernel.logs_dir%/%kernel.environment%.log"
+            path:  "%env(SYMFONY_LOG)%"
             level: debug
         console:
             type:  console

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -6,11 +6,11 @@ parameters:
     # this demo application uses an embedded SQLite database to simplify setup.
     # in a real Symfony application you probably will use a MySQL or PostgreSQL database
     # the path must be relative or else it will not work on Windows
-    database_url:      'sqlite:///%kernel.root_dir%/data/blog.sqlite'
+    env(DATABASE_URL): 'sqlite:///%kernel.root_dir%/data/blog.sqlite'
 
     # Uncomment this line to use a MySQL database instead of SQLite:
     #
-    # database_url:      'mysql://root:pass@127.0.0.1:3306/symfony_demo'
+    # env(DATABASE_URL): 'mysql://root:pass@127.0.0.1:3306/symfony_demo'
     #
     # Furthermore, you must remove or comment out the "doctrine" section from config_dev.yml regarding SQLite!
     #
@@ -35,4 +35,4 @@ parameters:
     # used internally by Symfony in several places (CSRF tokens, URI signing,
     # 'Remember Me' functionality, etc.)
     # see: http://symfony.com/doc/current/reference/configuration/framework.html#secret
-    secret: 'secret_value_for_symfony_demo_application'
+    env(SYMFONY_SECRET): 'secret_value_for_symfony_demo_application'

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -36,3 +36,6 @@ parameters:
     # 'Remember Me' functionality, etc.)
     # see: http://symfony.com/doc/current/reference/configuration/framework.html#secret
     env(SYMFONY_SECRET): 'secret_value_for_symfony_demo_application'
+
+    # Destination for log files; can also be "php://stderr" etc
+    env(SYMFONY_LOG):    %kernel.logs_dir%/%kernel.environment%.log

--- a/composer.json
+++ b/composer.json
@@ -64,11 +64,7 @@
         "symfony-tests-dir": "tests",
         "symfony-assets-install": "relative",
         "incenteev-parameters": {
-            "file": "app/config/parameters.yml",
-            "env-map": {
-                "database_url": "DATABASE_URL",
-                "secret": "SYMFONY_SECRET"
-            }
+            "file": "app/config/parameters.yml"
         }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "dcab3ad6f8670398e973ad35a9d3363e",
-    "content-hash": "06fff9225fbc56ff903173b460273352",
+    "hash": "6616cda63dceb16e22a667bfa5e4c179",
+    "content-hash": "e4f4c9803e3388e26151790dab13a1d2",
     "packages": [
         {
             "name": "doctrine/annotations",


### PR DESCRIPTION
Database, log destination, and secrets are now configurable via environment variables (via the quasi standard `DATABASE_URL`, and `SYMFONY_LOG`, and `SYMFONY_SECRET`). All three fall back to defaults from `parameters.yml(.dist)`.

For simplicity (one param versus many), a URL is now used again for SQLite, because that works fine since Doctrine DBAL 2.5.5.

Deploys to Heroku are now fixed again; @bocharsky-bw's PR #377 was not a fix for #371, because SQLite does not scale horizontally :p The original problem was @javiereguiluz's 56cfa66 change to Symfony 3.1, which used individual parameters for config. Again, no longer a problem since DBAL 2.5.5. It also uses `php://stderr` for env `prod` on Heroku only, which @javiereguiluz had also removed in 56cfa665cf1235c436c70afa5fc85c2668c14605 (for the future, I'd encourage separate commits for stuff like this, as it makes it much easier to untangle individual parts and reasons for changes).

This demo app ships with sample data in SQLite, but for other databases, the data needs to be seeded, and that can even happen in a prod env. @javiereguiluz' commit e2264b0 removed the fixtures bundle needed for that from the kernel init; it's now back.

This app now works just fine with the usual defaults both in `dev` and `prod` envs, but users who want to try running it on Docker or on a PaaS like Heroku can now trivially adjust relevant settings via environment variables.

/CC @stof @fabpot 