### PR TITLE
Updated some help notes for parameters.yml.dist

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -3,39 +3,40 @@
 # used by the application.
 # See http://symfony.com/doc/current/best_practices/configuration.html#canonical-parameters
 parameters:
+    # The code of the default language used by the application ('en' = English)
+    locale: en
+
+    # The 'secret' value is a random string of characters used by Symfony to
+    # to add more entropy to security related operations.
+    # see: http://symfony.com/doc/current/reference/configuration/framework.html#secret
+    env(SYMFONY_SECRET): 'secret_value_for_symfony_demo_application'
+
+    # Destination for log files; can also be "php://stderr" etc
+    env(SYMFONY_LOG): '%kernel.logs_dir%/%kernel.environment%.log'
+
     # this demo application uses an embedded SQLite database to simplify setup.
     # in a real Symfony application you probably will use a MySQL or PostgreSQL database
     # the path must be relative or else it will not work on Windows
     env(DATABASE_URL): 'sqlite:///%kernel.root_dir%/data/blog.sqlite'
 
-    # Uncomment this line to use a MySQL database instead of SQLite:
+    # Uncomment this line to use a MySQL database instead of SQLite (and remove
+    # the "doctrine" section from config_dev.yml regarding SQLite):
     #
     # env(DATABASE_URL): 'mysql://root:pass@127.0.0.1:3306/symfony_demo'
     #
-    # Furthermore, you must remove or comment out the "doctrine" section from config_dev.yml regarding SQLite!
-    #
-    # You can even create the database and load the sample data from the command line:
+    # You can also create the database and load the sample data from the command line:
     #
     # $ cd symfony-demo/
     # $ php bin/console doctrine:database:create
     # $ php bin/console doctrine:schema:create
     # $ php bin/console doctrine:fixtures:load
 
+    # Uncomment these parameters if your application sends emails:
+    #
+    # mailer_transport:  smtp
+    # mailer_host:       127.0.0.1
+    # mailer_user:       ~
+    # mailer_password:   ~
+    #
     # If you don't use a real mail server, you can send emails via your Gmail account.
     # see http://symfony.com/doc/current/cookbook/email/gmail.html
-    mailer_transport:  smtp
-    mailer_host:       127.0.0.1
-    mailer_user:       ~
-    mailer_password:   ~
-
-    # The code of the default language used by the application ('en' = English)
-    locale: en
-
-    # The 'secret' value is a random string of characters, numbers and symbols
-    # used internally by Symfony in several places (CSRF tokens, URI signing,
-    # 'Remember Me' functionality, etc.)
-    # see: http://symfony.com/doc/current/reference/configuration/framework.html#secret
-    env(SYMFONY_SECRET): 'secret_value_for_symfony_demo_application'
-
-    # Destination for log files; can also be "php://stderr" etc
-    env(SYMFONY_LOG):    %kernel.logs_dir%/%kernel.environment%.log


### PR DESCRIPTION
* Short params have been moved at the top of the file because `env(DATABASE_URL)` is too long and hides them
* `env(SYMFONY_LOG)` value is now wrapped in quotes to avoid deprecations
* Simplified `env(SYMFONY_SECRET)` description
* Commented the params related to the mailer (because the mailer is already disabled in the application)