### PR TITLE
Fix error with class redeclaration: Do not load cache files on PHP 7

### DIFF
--- a/web/app.php
+++ b/web/app.php
@@ -11,7 +11,9 @@ use Symfony\Component\HttpFoundation\Request;
  * @var Composer\Autoload\ClassLoader
  */
 $loader = require __DIR__.'/../app/autoload.php';
-include_once __DIR__.'/../var/bootstrap.php.cache';
+if (PHP_VERSION_ID < 70000) {
+    include_once __DIR__.'/../var/bootstrap.php.cache';
+}
 
 // If your web server provides APC support for PHP applications, uncomment these
 // lines to use APC for class autoloading. This can improve application performance
@@ -27,7 +29,9 @@ include_once __DIR__.'/../var/bootstrap.php.cache';
 // $apcLoader->register(true);
 
 $kernel = new AppKernel('prod', false);
-$kernel->loadClassCache();
+if (PHP_VERSION_ID < 70000) {
+    $kernel->loadClassCache();
+}
 
 // When using the HTTP Cache to improve application performance, the application
 // kernel is wrapped by the AppCache class to activate the built-in reverse proxy.

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -29,7 +29,9 @@ $loader = require __DIR__.'/../app/autoload.php';
 Debug::enable();
 
 $kernel = new AppKernel('dev', true);
-$kernel->loadClassCache();
+if (PHP_VERSION_ID < 70000) {
+    $kernel->loadClassCache();
+}
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();


### PR DESCRIPTION
Fix #411

I think this error could be related to the https://github.com/symfony/symfony-standard/pull/1030
