### PR TITLE
Sort new Composer packages automatically

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,8 @@
     "config": {
         "platform": {
             "php": "5.5.9"
-        }
+        },
+        "sort-packages": true
     },
     "extra": {
         "symfony-app-dir": "app",


### PR DESCRIPTION
Related to the https://github.com/symfony/symfony-standard/pull/1036

However, I think it makes even more sense here since we have already sorted packages in composer.json.
