### PR TITLE
Added an event subscriber to display better error messages in the console

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -31,9 +31,9 @@ services:
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
 
-    # Event subscribers are similar to event listeners. The main difference is
-    # that the classes define the events they listen to, instead of defining them
-    # in the service definition.
+    # Event subscribers are similar to event listeners but they don't need service tags.
+    # Instead, the PHP class of the event subscriber includes a method that returns
+    # the list of events listened by that class.
     # See http://symfony.com/doc/current/event_dispatcher.html#creating-an-event-subscriber
     app.console_subscriber:
         class: AppBundle\EventListener\ConsoleEventSubscriber

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -28,6 +28,11 @@ services:
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
 
+    app.console_subscriber:
+        class: AppBundle\EventListener\ConsoleEventSubscriber
+        tags:
+            - { name: kernel.event_subscriber }
+
     # Uncomment the following lines to define a service for the Post Doctrine repository.
     # It's not mandatory to create these services, but if you use repositories a lot,
     # these services simplify your code:

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -22,12 +22,19 @@ services:
         tags:
             - { name: twig.extension }
 
+    # Event Listeners are classes that listen to one or more specific events.
+    # Those events are defined in the tags added to the service definition.
+    # See http://symfony.com/doc/current/event_dispatcher.html#creating-an-event-listener
     app.redirect_to_preferred_locale_listener:
         class: AppBundle\EventListener\RedirectToPreferredLocaleListener
         arguments: ['@router', '%app_locales%', '%locale%']
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
 
+    # Event subscribers are similar to event listeners. The main difference is
+    # that the classes define the events they listen to, instead of defining them
+    # in the service definition.
+    # See http://symfony.com/doc/current/event_dispatcher.html#creating-an-event-subscriber
     app.console_subscriber:
         class: AppBundle\EventListener\ConsoleEventSubscriber
         tags:

--- a/src/AppBundle/EventListener/ConsoleEventSubscriber.php
+++ b/src/AppBundle/EventListener/ConsoleEventSubscriber.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AppBundle\EventListener;
+
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleExceptionEvent;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class ConsoleEventSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return array(
+            ConsoleEvents::EXCEPTION => 'displayBetterErrorMessages',
+        );
+    }
+
+    public function displayBetterErrorMessages(ConsoleExceptionEvent $event)
+    {
+        $commandNames = ['doctrine:fixtures:load', 'doctrine:database:create', 'doctrine:schema:create', 'doctrine:database:drop'];
+
+        if (in_array($event->getCommand()->getName(), $commandNames)) {
+            if (!extension_loaded('sqlite3')) {
+                $io = new SymfonyStyle($event->getInput(), $event->getOutput());
+                $io->error('This command requires to have the "sqlite3" PHP extension enabled because, by default, the Symfony Demo application uses SQLite to store its information.');
+            }
+        }
+    }
+}

--- a/src/AppBundle/EventListener/ConsoleEventSubscriber.php
+++ b/src/AppBundle/EventListener/ConsoleEventSubscriber.php
@@ -20,9 +20,9 @@ class ConsoleEventSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents()
     {
-        return array(
+        return [
             ConsoleEvents::EXCEPTION => 'displayBetterErrorMessages',
-        );
+        ];
     }
 
     public function displayBetterErrorMessages(ConsoleExceptionEvent $event)

--- a/src/AppBundle/EventListener/ConsoleEventSubscriber.php
+++ b/src/AppBundle/EventListener/ConsoleEventSubscriber.php
@@ -16,16 +16,37 @@ use Symfony\Component\Console\Event\ConsoleExceptionEvent;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
+/**
+ * This application uses by default a SQLite database to store its information.
+ * That's why the 'sqlite3' extension must be enabled in PHP. This event
+ * subscriber listens to console events and in case of an exception caused by
+ * a disabled 'sqlite3' extension, it displays a meaningful error message.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
 class ConsoleEventSubscriber implements EventSubscriberInterface
 {
+    // Event Subscribers must define this method to declare the events they
+    // listen to. You can listen to several events, execute more than one method
+    // for each event and set the priority of each event too.
+    // See http://symfony.com/doc/current/event_dispatcher.html#creating-an-event-subscriber
     public static function getSubscribedEvents()
     {
         return [
-            ConsoleEvents::EXCEPTION => 'displayBetterErrorMessages',
+            // Exceptions are one of the events defined by the Console. See the
+            // rest here: http://symfony.com/doc/current/components/console/events.html
+            ConsoleEvents::EXCEPTION => 'handleDatabaseExceptions',
         ];
     }
 
-    public function displayBetterErrorMessages(ConsoleExceptionEvent $event)
+    /**
+     * This method checks if there has been an exception in a command related to
+     * the database and then, it checks if the 'sqlite3' PHP extension is enabled
+     * or not to display a better error message.
+     *
+     * @param ConsoleExceptionEvent $event
+     */
+    public function handleDatabaseExceptions(ConsoleExceptionEvent $event)
     {
         $commandNames = ['doctrine:fixtures:load', 'doctrine:database:create', 'doctrine:schema:create', 'doctrine:database:drop'];
 

--- a/src/AppBundle/EventListener/ConsoleEventSubscriber.php
+++ b/src/AppBundle/EventListener/ConsoleEventSubscriber.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
- * This application uses by default a SQLite database to store its information.
+ * This application uses by default an SQLite database to store its information.
  * That's why the 'sqlite3' extension must be enabled in PHP. This event
  * subscriber listens to console events and in case of an exception caused by
  * a disabled 'sqlite3' extension, it displays a meaningful error message.


### PR DESCRIPTION
I propose this PR because:

* It could solve problems like #418
* It allows us to introduce an event subscriber (so far we only have an event listener)

If you agree, I'll polish this and add some helpful comments:

![console_exception](https://cloud.githubusercontent.com/assets/73419/21689124/aa8de6a6-d36f-11e6-8f85-222c2bcaeaca.png)
