### PR TITLE
Use font-awesome icon in "form_errors" block

### DIFF
--- a/app/Resources/views/form/layout.html.twig
+++ b/app/Resources/views/form/layout.html.twig
@@ -1,0 +1,16 @@
+{% extends 'bootstrap_3_layout.html.twig' %}
+
+{# Errors #}
+
+{% block form_errors -%}
+    {% if errors|length > 0 -%}
+        {% if form.parent %}<span class="help-block">{% else %}<div class="alert alert-danger">{% endif %}
+        <ul class="list-unstyled">
+        {%- for error in errors -%}
+            {# use font-awesome icon library #}
+            <li><span class="fa fa-exclamation-triangle"></span> {{ error.message }}</li>
+        {%- endfor -%}
+        </ul>
+        {% if form.parent %}</span>{% else %}</div>{% endif %}
+    {%- endif %}
+{%- endblock form_errors %}

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -55,7 +55,7 @@ twig:
     debug:            "%kernel.debug%"
     strict_variables: "%kernel.debug%"
     form_themes:
-        - "bootstrap_3_layout.html.twig"
+        - "form/layout.html.twig"
         - "form/fields.html.twig"
 
 # Doctrine Configuration (used to access databases and manipulate their information)
@@ -63,7 +63,7 @@ doctrine:
     dbal:
         # if you don't want to use SQLite, change the URL in parameters.yml or set the DATABASE_URL environment variable
         url: "%env(DATABASE_URL)%"
-        
+
         # instead of using a URL, you may also uncomment the following lines to configure your database
         # driver:   pdo_mysql
         # host:     "%database_host%"


### PR DESCRIPTION
By default [`bootstrap_3_layout.html.twig` template use `glyphicon-` icon when the `form_errors` block is rendered](https://github.com/symfony/symfony/blob/master/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig#L259). In this demo app we use font-awesome (`fa-`) icon library, so this PR try to fix that.

| Before | After |
| ---- | ---- |
| ![post-comment-error](https://cloud.githubusercontent.com/assets/2028198/21733360/1098de26-d42c-11e6-92f7-a8f5b54e09b1.png)  | ![post-comment-fixed](https://cloud.githubusercontent.com/assets/2028198/21733425/5fddca46-d42c-11e6-9ede-4e1846aa01f7.png)  |

