### PR TITLE
Design tweaks for small screens

### DIFF
--- a/web/css/main.css
+++ b/web/css/main.css
@@ -244,3 +244,9 @@ body#admin_post_index .item-actions {
 body#admin_post_index .item-actions a.btn + a.btn {
     margin-left: 4px
 }
+
+@media (min-width: 768px) and (max-width: 1200px) {
+    .container {
+        width: 98%;
+    }
+}


### PR DESCRIPTION
A typical problem I see with lots of Bootstrap-based templates is that they look awful in a very specific range of page widths. When the browser window is not too small and not too big, the template constraints the container width too much. This PR tries to fix this.

| Before | After
| --- | ---
| ![before_container](https://cloud.githubusercontent.com/assets/73419/21886280/5ec58cfa-d8bb-11e6-9b00-fb72cfa30ce4.png) | ![after_container](https://cloud.githubusercontent.com/assets/73419/21886283/5ff8869a-d8bb-11e6-80e4-20c87b9fd059.png)

