### PR TITLE
By default redirect to post index page after login

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -32,6 +32,8 @@ security:
                 # Secure the login form against CSRF
                 # Reference: http://symfony.com/doc/current/cookbook/security/csrf_in_login_form.html
                 csrf_token_generator: security.csrf.token_manager
+                # Redirect to post index page after login (by default)
+                default_target_path: blog_index
 
             logout:
                 # The route name the user can go to in order to logout

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -32,9 +32,8 @@ security:
                 # Secure the login form against CSRF
                 # Reference: http://symfony.com/doc/current/cookbook/security/csrf_in_login_form.html
                 csrf_token_generator: security.csrf.token_manager
-                # After login, users are redirected by default to their previous page. This
-                # value is only used when the referrer page does not exist (e.g. when
-                # accessing directly to the login page)
+                # The page users are redirect to when there is no previous page stored in the
+                # session (for example when the users access directly to the login page).
                 default_target_path: blog_index
 
             logout:

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -32,7 +32,9 @@ security:
                 # Secure the login form against CSRF
                 # Reference: http://symfony.com/doc/current/cookbook/security/csrf_in_login_form.html
                 csrf_token_generator: security.csrf.token_manager
-                # Redirect to post index page after login (by default)
+                # After login, users are redirected by default to their previous page. This
+                # value is only used when the referrer page does not exist (e.g. when
+                # accessing directly to the login page)
                 default_target_path: blog_index
 
             logout:


### PR DESCRIPTION
This PR change the default target path `/` to <del>`admin_index`</del> `blog_index` route, useful when we access to login page directly (i.e. through URL).