### PR TITLE
Tweaked the admin form views

### DIFF
--- a/app/Resources/views/admin/blog/new.html.twig
+++ b/app/Resources/views/admin/blog/new.html.twig
@@ -9,13 +9,10 @@
         {{ form_row(form.title) }}
         {{ form_row(form.summary) }}
         {{ form_row(form.content) }}
-        {{ form_row(form.authorEmail) }}
         {{ form_row(form.publishedAt) }}
 
         <input type="submit" value="{{ 'label.create_post'|trans }}" class="btn btn-primary" />
-
         {{ form_widget(form.saveAndCreateNew, { label: 'label.save_and_create_new', attr: { class: 'btn btn-primary' } }) }}
-
         <a href="{{ path('admin_post_index') }}" class="btn btn-link">
             {{ 'action.back_to_list'|trans }}
         </a>

--- a/src/AppBundle/Form/PostType.php
+++ b/src/AppBundle/Form/PostType.php
@@ -49,13 +49,16 @@ class PostType extends AbstractType
                 'label' => 'label.summary',
             ])
             ->add('content', null, [
-                'attr' => ['rows' => 20],
+                'attr' => [
+                    'rows' => 20,
+                    'help' => 'Markdown is allowed.',
+                ],
                 'label' => 'label.content',
             ])
-            ->add('authorEmail', null, [
-                'label' => 'label.author_email',
-            ])
             ->add('publishedAt', DateTimePickerType::class, [
+                'attr' => [
+                    'help' => 'Dates in the future are allowed. Posts won\'t be displayed until that date.',
+                ],
                 'label' => 'label.published_at',
             ])
         ;

--- a/src/AppBundle/Form/PostType.php
+++ b/src/AppBundle/Form/PostType.php
@@ -49,16 +49,10 @@ class PostType extends AbstractType
                 'label' => 'label.summary',
             ])
             ->add('content', null, [
-                'attr' => [
-                    'rows' => 20,
-                    'help' => 'Markdown is allowed.',
-                ],
+                'attr' => ['rows' => 20],
                 'label' => 'label.content',
             ])
             ->add('publishedAt', DateTimePickerType::class, [
-                'attr' => [
-                    'help' => 'Dates in the future are allowed. Posts won\'t be displayed until that date.',
-                ],
                 'label' => 'label.published_at',
             ])
         ;

--- a/web/css/main.css
+++ b/web/css/main.css
@@ -142,8 +142,12 @@ footer #footer-resources i {
     padding: 1em
 }
 
-.form-group.has-error .help-block ul {
+.form-group.has-error .help-block ul,
+.form-group.has-error .help-block li {
     margin-bottom: 0
+}
+.form-group.has-error .help-block li + li {
+    margin-top: 0.5em;
 }
 
 textarea {


### PR DESCRIPTION
* Removed the author email from the form (you can only create posts for yourself)
* Added some help messages for form fields (they are not displayed to the end-user yet)
* Tweaks to the design of the error messages:

| Before | After
| --- | ---
| ![before-error](https://cloud.githubusercontent.com/assets/73419/22024956/2056efd0-dccc-11e6-93fd-4bcd5c2b401a.png) | ![after-error](https://cloud.githubusercontent.com/assets/73419/22024959/20f2fa24-dccc-11e6-846b-c5338cba3511.png)

