### PR TITLE
Add a security Post Voter

### DIFF
--- a/app/Resources/views/blog/post_show.html.twig
+++ b/app/Resources/views/blog/post_show.html.twig
@@ -55,7 +55,7 @@
 {% endblock %}
 
 {% block sidebar %}
-    {% if post.isAuthor(app.user) %}
+    {% if is_granted('edit', post) %}
         <div class="section">
             <a class="btn btn-lg btn-block btn-success" href="{{ path('admin_post_edit', { id: post.id }) }}">
                 <i class="fa fa-edit" aria-hidden="true"></i> {{ 'action.edit_post'|trans }}

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -48,6 +48,14 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
+    # To inject the voter into the security layer, you must declare it as a service and tag it with security.voter.
+    # See http://symfony.com/doc/current/security/voters.html#configuring-the-voter
+    app.post_voter:
+        class: AppBundle\Security\PostVoter
+        public: false
+        tags:
+            - { name: security.voter }
+
     # Uncomment the following lines to define a service for the Post Doctrine repository.
     # It's not mandatory to create these services, but if you use repositories a lot,
     # these services simplify your code:

--- a/src/AppBundle/Controller/Admin/BlogController.php
+++ b/src/AppBundle/Controller/Admin/BlogController.php
@@ -119,12 +119,9 @@ class BlogController extends Controller
      */
     public function showAction(Post $post)
     {
-        // This security check can also be performed:
-        //   1. Using an annotation: @Security("post.isAuthor(user)")
-        //   2. Using a "voter" (see http://symfony.com/doc/current/cookbook/security/voters_data_permission.html)
-        if (!$post->isAuthor($this->getUser())) {
-            throw $this->createAccessDeniedException('Posts can only be shown to their authors.');
-        }
+        // This security check can also be performed
+        // using an annotation: @Security("is_granted('show', post)")
+        $this->denyAccessUnlessGranted('show', $post, 'Posts can only be shown to their authors.');
 
         return $this->render('admin/blog/show.html.twig', [
             'post' => $post,
@@ -139,9 +136,7 @@ class BlogController extends Controller
      */
     public function editAction(Post $post, Request $request)
     {
-        if (!$post->isAuthor($this->getUser())) {
-            throw $this->createAccessDeniedException('Posts can only be edited by their authors.');
-        }
+        $this->denyAccessUnlessGranted('edit', $post, 'Posts can only be edited by their authors.');
 
         $entityManager = $this->getDoctrine()->getManager();
 
@@ -169,11 +164,10 @@ class BlogController extends Controller
      *
      * @Route("/{id}/delete", name="admin_post_delete")
      * @Method("POST")
-     * @Security("post.isAuthor(user)")
+     * @Security("is_granted('delete', post)")
      *
      * The Security annotation value is an expression (if it evaluates to false,
      * the authorization mechanism will prevent the user accessing this resource).
-     * The isAuthor() method is defined in the AppBundle\Entity\Post entity.
      */
     public function deleteAction(Request $request, Post $post)
     {

--- a/src/AppBundle/Security/PostVoter.php
+++ b/src/AppBundle/Security/PostVoter.php
@@ -53,8 +53,8 @@ class PostVoter extends Voter
             return false;
         }
 
-        // the logic of this voter is pretty simple: if the given user is the
-        // author of the blog post, grant permission; otherwise, deny it.
+        // the logic of this voter is pretty simple: if the logged user is the
+        // author of the given blog post, grant permission; otherwise, deny it.
         // (the supports() method guarantees that $post is a Post object)
         return $user === $post->getAuthor();
     }

--- a/src/AppBundle/Security/PostVoter.php
+++ b/src/AppBundle/Security/PostVoter.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AppBundle\Security;
+
+use AppBundle\Entity\Post;
+use AppBundle\Entity\User;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+/**
+ * Decide whether the current user can show, edit or delete a Post object.
+ *
+ * See http://symfony.com/doc/current/security/voters.html
+ *
+ * @author Yonel Ceruto <yonelceruto@gmail.com>
+ */
+class PostVoter extends Voter
+{
+    const SHOW = 'show';
+    const EDIT = 'edit';
+    const DELETE = 'delete';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function supports($attribute, $subject)
+    {
+        // if the attribute isn't one we support, return false
+        if (!in_array($attribute, [self::SHOW, self::EDIT, self::DELETE])) {
+            return false;
+        }
+
+        // only vote on Post objects inside this voter
+        if (!$subject instanceof Post) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function voteOnAttribute($attribute, $post, TokenInterface $token)
+    {
+        $user = $token->getUser();
+
+        if (!$user instanceof User) {
+            // the user must be logged in; if not, deny access
+            return false;
+        }
+
+        // you know $post is a Post object, thanks to supports
+        return $user === $post->getAuthor();
+    }
+}


### PR DESCRIPTION
Implement https://github.com/symfony/symfony-demo/issues/440 feature.

- [x] Add more code comments and doc references

Following some references and recommendations in:
- https://symfony.com/doc/current/components/security/authorization.html
- http://symfony.com/doc/current/security/voters.html
- https://stovepipe.systems/post/symfony-security-roles-vs-voters (@iltar blog)

Any suggestion is welcome!