### PR TITLE
Delete all post/tag entries on delete a Post

### DIFF
--- a/src/AppBundle/Controller/Admin/BlogController.php
+++ b/src/AppBundle/Controller/Admin/BlogController.php
@@ -177,6 +177,10 @@ class BlogController extends Controller
 
         $entityManager = $this->getDoctrine()->getManager();
 
+        // Delete related symfony_demo_post_tag entries. This is necessary for SQLite platform only,
+        // you can remove it for another platform.
+        $post->getTags()->clear();
+
         $entityManager->remove($post);
         $entityManager->flush();
 

--- a/src/AppBundle/Controller/Admin/BlogController.php
+++ b/src/AppBundle/Controller/Admin/BlogController.php
@@ -177,8 +177,9 @@ class BlogController extends Controller
 
         $entityManager = $this->getDoctrine()->getManager();
 
-        // Delete related symfony_demo_post_tag entries. This is necessary for SQLite platform only,
-        // you can remove it for another platform.
+        // Delete the tags associated with this blog post. This is done automatically
+        // by Doctrine, except for SQLite (the database used in this application)
+        // because foreign key support is not enabled by default in SQLite
         $post->getTags()->clear();
 
         $entityManager->remove($post);


### PR DESCRIPTION
We can't use cascade delete constraint in this case because Foreign key support is not enabled in SQLite by default. (https://www.sqlite.org/foreignkeys.html#fk_enable)

More information about it:
- https://github.com/doctrine/dbal/issues/2104
- https://github.com/doctrine/dbal/issues/1204

So my only one solution was to clear this relations manually.