### PR TITLE
Reduce DB query number in post index action

### DIFF
--- a/src/AppBundle/Repository/PostRepository.php
+++ b/src/AppBundle/Repository/PostRepository.php
@@ -52,7 +52,7 @@ class PostRepository extends EntityRepository
 
     private function createPaginator(Query $query, $page)
     {
-        $paginator = new Pagerfanta(new DoctrineORMAdapter($query, false));
+        $paginator = new Pagerfanta(new DoctrineORMAdapter($query));
         $paginator->setMaxPerPage(Post::NUM_ITEMS);
         $paginator->setCurrentPage($page);
 

--- a/src/AppBundle/Repository/PostRepository.php
+++ b/src/AppBundle/Repository/PostRepository.php
@@ -25,15 +25,18 @@ use Pagerfanta\Pagerfanta;
  *
  * @author Ryan Weaver <weaverryan@gmail.com>
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ * @author Yonel Ceruto <yonelceruto@gmail.com>
  */
 class PostRepository extends EntityRepository
 {
     /**
-     * @return Query
+     * @param int $page
+     *
+     * @return Pagerfanta
      */
-    public function queryLatest()
+    public function findLatest($page = 1)
     {
-        return $this->getEntityManager()
+        $query = $this->getEntityManager()
             ->createQuery('
                 SELECT p, t
                 FROM AppBundle:Post p
@@ -43,16 +46,13 @@ class PostRepository extends EntityRepository
             ')
             ->setParameter('now', new \DateTime())
         ;
+
+        return $this->createPaginator($query, $page);
     }
 
-    /**
-     * @param int $page
-     *
-     * @return Pagerfanta
-     */
-    public function findLatest($page = 1)
+    private function createPaginator(Query $query, $page)
     {
-        $paginator = new Pagerfanta(new DoctrineORMAdapter($this->queryLatest(), false));
+        $paginator = new Pagerfanta(new DoctrineORMAdapter($query, false));
         $paginator->setMaxPerPage(Post::NUM_ITEMS);
         $paginator->setCurrentPage($page);
 

--- a/src/AppBundle/Repository/PostRepository.php
+++ b/src/AppBundle/Repository/PostRepository.php
@@ -35,8 +35,9 @@ class PostRepository extends EntityRepository
     {
         return $this->getEntityManager()
             ->createQuery('
-                SELECT p
+                SELECT p, t
                 FROM AppBundle:Post p
+                LEFT JOIN p.tags t
                 WHERE p.publishedAt <= :now
                 ORDER BY p.publishedAt DESC
             ')


### PR DESCRIPTION
**Performance Issue**

After tags feature the blog index page performs one extra query for each post to fetches its related tags. This PR avoids that.

Other changes:
* Refactoring the Post repository methods to reuse paginator creation in the future.