### PR TITLE
Fix translating "limit" variable: add extra spaces

### DIFF
--- a/app/Resources/translations/validators.uk.xlf
+++ b/app/Resources/translations/validators.uk.xlf
@@ -12,7 +12,7 @@
             </trans-unit>
             <trans-unit id="post.too_short_content">
                 <source>post.too_short_content</source>
-                <target>Зміст запису занадто короткий (мінімум {{limit}} символів).</target>
+                <target>Зміст запису занадто короткий (мінімум {{ limit }} символів).</target>
             </trans-unit>
             <trans-unit id="comment.blank">
                 <source>comment.blank</source>
@@ -20,11 +20,11 @@
             </trans-unit>
             <trans-unit id="comment.too_short">
                 <source>comment.too_short</source>
-                <target>Коментар занадто короткий, (мінімум {{limit}} символів).</target>
+                <target>Коментар занадто короткий, (мінімум {{ limit }} символів).</target>
             </trans-unit>
             <trans-unit id="comment.too_long">
                 <source>comment.too_long</source>
-                <target>Коментар занадто довгий, (максимум {{limit}} символів).</target>
+                <target>Коментар занадто довгий, (максимум {{ limit }} символів).</target>
             </trans-unit>
             <trans-unit id="comment.is_spam">
                 <source>comment.is_spam</source>


### PR DESCRIPTION
`{{limit}}` not translated at all.