### PR TITLE
Fixed typo in polish translations

### DIFF
--- a/app/Resources/translations/messages.pl.xlf
+++ b/app/Resources/translations/messages.pl.xlf
@@ -237,7 +237,7 @@
             </trans-unit>
             <trans-unit id="help.app_description">
                 <source>help.app_description</source>
-                <target><![CDATA[To jest <strong> przykładowa aplikacja </strong> zbudowana przy pomocy frameworka Symfony, dla zademonostrowania polecanego sposobu tworzenia aplikacji przy jego użyciu.]]></target>
+                <target><![CDATA[To jest <strong> przykładowa aplikacja </strong> zbudowana przy pomocy frameworka Symfony, dla zademonstrowania polecanego sposobu tworzenia aplikacji przy jego użyciu.]]></target>
             </trans-unit>
             <trans-unit id="help.show_code">
                 <source>help.show_code</source>


### PR DESCRIPTION
There is nothing like "zademonostrowania". It is like english `demonstrate` vs `demonostrate`.