### PR TITLE
Remove unused tag

### DIFF
--- a/src/AppBundle/Controller/Admin/BlogController.php
+++ b/src/AppBundle/Controller/Admin/BlogController.php
@@ -12,6 +12,7 @@
 namespace AppBundle\Controller\Admin;
 
 use AppBundle\Entity\Post;
+use AppBundle\Entity\Tag;
 use AppBundle\Form\PostType;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
@@ -147,6 +148,7 @@ class BlogController extends Controller
         if ($form->isSubmitted() && $form->isValid()) {
             $post->setSlug($this->get('slugger')->slugify($post->getTitle()));
             $entityManager->flush();
+            $this->getDoctrine()->getRepository(Tag::class)->cleanUnusedTags();
 
             $this->addFlash('success', 'post.updated_successfully');
 
@@ -184,6 +186,7 @@ class BlogController extends Controller
 
         $entityManager->remove($post);
         $entityManager->flush();
+        $this->getDoctrine()->getRepository(Tag::class)->cleanUnusedTags();
 
         $this->addFlash('success', 'post.deleted_successfully');
 

--- a/src/AppBundle/Entity/Tag.php
+++ b/src/AppBundle/Entity/Tag.php
@@ -5,7 +5,7 @@ namespace AppBundle\Entity;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * @ORM\Entity()
+ * @ORM\Entity(repositoryClass="AppBundle\Repository\TagRepository")
  * @ORM\Table(name="symfony_demo_tag")
  *
  * Defines the properties of the Tag entity to represent the post tags.
@@ -24,6 +24,13 @@ class Tag implements \JsonSerializable
      * @ORM\Column(type="integer")
      */
     private $id;
+
+    /**
+     * @var array
+     *
+     * @ORM\ManyToMany(targetEntity="AppBundle\Entity\Post", mappedBy="tags")
+     */
+    private $posts;
 
     /**
      * @var string
@@ -65,5 +72,46 @@ class Tag implements \JsonSerializable
     public function __toString()
     {
         return $this->name;
+    }
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->posts = new \Doctrine\Common\Collections\ArrayCollection();
+    }
+
+    /**
+     * Add post
+     *
+     * @param \AppBundle\Entity\Post $post
+     *
+     * @return Tag
+     */
+    public function addPost(\AppBundle\Entity\Post $post)
+    {
+        $this->posts[] = $post;
+
+        return $this;
+    }
+
+    /**
+     * Remove post
+     *
+     * @param \AppBundle\Entity\Post $post
+     */
+    public function removePost(\AppBundle\Entity\Post $post)
+    {
+        $this->posts->removeElement($post);
+    }
+
+    /**
+     * Get posts
+     *
+     * @return \Doctrine\Common\Collections\Collection
+     */
+    public function getPosts()
+    {
+        return $this->posts;
     }
 }

--- a/src/AppBundle/Entity/Tag.php
+++ b/src/AppBundle/Entity/Tag.php
@@ -26,13 +26,6 @@ class Tag implements \JsonSerializable
     private $id;
 
     /**
-     * @var array
-     *
-     * @ORM\ManyToMany(targetEntity="AppBundle\Entity\Post", mappedBy="tags")
-     */
-    private $posts;
-
-    /**
      * @var string
      *
      * @ORM\Column(type="string", unique=true)
@@ -72,46 +65,5 @@ class Tag implements \JsonSerializable
     public function __toString()
     {
         return $this->name;
-    }
-    /**
-     * Constructor
-     */
-    public function __construct()
-    {
-        $this->posts = new \Doctrine\Common\Collections\ArrayCollection();
-    }
-
-    /**
-     * Add post
-     *
-     * @param \AppBundle\Entity\Post $post
-     *
-     * @return Tag
-     */
-    public function addPost(\AppBundle\Entity\Post $post)
-    {
-        $this->posts[] = $post;
-
-        return $this;
-    }
-
-    /**
-     * Remove post
-     *
-     * @param \AppBundle\Entity\Post $post
-     */
-    public function removePost(\AppBundle\Entity\Post $post)
-    {
-        $this->posts->removeElement($post);
-    }
-
-    /**
-     * Get posts
-     *
-     * @return \Doctrine\Common\Collections\Collection
-     */
-    public function getPosts()
-    {
-        return $this->posts;
     }
 }

--- a/src/AppBundle/Repository/TagRepository.php
+++ b/src/AppBundle/Repository/TagRepository.php
@@ -17,16 +17,14 @@ use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Query\ResultSetMapping;
 
 /**
- * This custom Doctrine repository contains some methods which are useful when
- * querying tags and
+ * This custom Doctrine repository contains some methods to about tags.
  *
  * See http://symfony.com/doc/current/book/doctrine.html#custom-repository-classes
- *
  */
 class TagRepository extends EntityRepository
 {
     /**
-     * Remove unused Tag from the Database
+     * Remove unused Tag from the Database.
      */
     public function cleanUnusedTags()
     {

--- a/src/AppBundle/Repository/TagRepository.php
+++ b/src/AppBundle/Repository/TagRepository.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AppBundle\Repository;
+
+use AppBundle\Entity\Tag;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Query;
+use Pagerfanta\Adapter\DoctrineORMAdapter;
+use Pagerfanta\Pagerfanta;
+
+/**
+ * This custom Doctrine repository contains some methods which are useful when
+ * querying for blog post information.
+ *
+ * See http://symfony.com/doc/current/book/doctrine.html#custom-repository-classes
+ *
+ * @author Ryan Weaver <weaverryan@gmail.com>
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ * @author Yonel Ceruto <yonelceruto@gmail.com>
+ */
+class TagRepository extends EntityRepository
+{
+    /**
+     * @param int $page
+     *
+     * @return Pagerfanta
+     */
+    public function cleanUnusedTags()
+    {
+        $unused_tags = $this->getEntityManager()
+            ->createQuery('
+                SELECT t.id
+                FROM AppBundle:Tag t
+                LEFT JOIN t.posts p
+                WHERE p.id IS NULL 
+            ')->getResult();
+        if (!empty($unused_tags)) {
+            $tag_ids = array_map(function ($tag) {
+                return $tag['id'];
+            }, $unused_tags);
+            $this->getEntityManager()
+                ->createQuery('DELETE FROM AppBundle:Tag t WHERE t.id IN (:tags)')
+                ->setParameter('tags', $tag_ids)
+                ->execute();
+        }
+    }
+}

--- a/src/AppBundle/Repository/TagRepository.php
+++ b/src/AppBundle/Repository/TagRepository.php
@@ -11,46 +11,34 @@
 
 namespace AppBundle\Repository;
 
+use AppBundle\Entity\Post;
 use AppBundle\Entity\Tag;
 use Doctrine\ORM\EntityRepository;
-use Doctrine\ORM\Query;
-use Pagerfanta\Adapter\DoctrineORMAdapter;
-use Pagerfanta\Pagerfanta;
+use Doctrine\ORM\Query\ResultSetMapping;
 
 /**
  * This custom Doctrine repository contains some methods which are useful when
- * querying for blog post information.
+ * querying tags and
  *
  * See http://symfony.com/doc/current/book/doctrine.html#custom-repository-classes
  *
- * @author Ryan Weaver <weaverryan@gmail.com>
- * @author Javier Eguiluz <javier.eguiluz@gmail.com>
- * @author Yonel Ceruto <yonelceruto@gmail.com>
  */
 class TagRepository extends EntityRepository
 {
     /**
-     * @param int $page
-     *
-     * @return Pagerfanta
+     * Remove unused Tag from the Database
      */
     public function cleanUnusedTags()
     {
-        $unused_tags = $this->getEntityManager()
-            ->createQuery('
-                SELECT t.id
-                FROM AppBundle:Tag t
-                LEFT JOIN t.posts p
-                WHERE p.id IS NULL 
-            ')->getResult();
-        if (!empty($unused_tags)) {
-            $tag_ids = array_map(function ($tag) {
-                return $tag['id'];
-            }, $unused_tags);
-            $this->getEntityManager()
-                ->createQuery('DELETE FROM AppBundle:Tag t WHERE t.id IN (:tags)')
-                ->setParameter('tags', $tag_ids)
-                ->execute();
-        }
+        $joinTable = $this->getEntityManager()->getClassMetadata(Post::class)->getAssociationMapping('tags')['joinTable']['name'];
+        $tagTable = $this->getClassMetadata()->getTableName();
+        $unused_tags = $this->getEntityManager()->createNativeQuery("
+            DELETE FROM `$tagTable` WHERE id IN 
+            (
+                SELECT t.id FROM `$tagTable` t
+                LEFT JOIN `$joinTable` j ON j.tag_id = t.id
+                WHERE j.tag_id IS NULL
+            )
+        ", new ResultSetMapping())->execute();
     }
 }


### PR DESCRIPTION
When a tag is detached from a post it stays in the Tag table filling the table over time. When we update (or delete a post) we clean up unused (unlinked tags)

## Improvments ideas 💡 

- I wanted to add this behaviour in an EventSubscriber but I don't know how to detect when a tag relation is persisted
- The query to get unused tag could be improved avoiding the double LEFT JOIN, but I don't know how to ask doctrine to limit the LEFT JOIN to the relation table.