### PR TITLE
Add a complete test for AddUserCommand

### DIFF
--- a/tests/AppBundle/Command/AddUserCommandTest.php
+++ b/tests/AppBundle/Command/AddUserCommandTest.php
@@ -76,7 +76,7 @@ class AddUserCommandTest extends KernelTestCase
 
     /**
      * This helper method checks that the user was correctly created and saved
-     * it in the database.
+     * in the database.
      */
     private function assertUserCreated($isAdmin)
     {
@@ -94,10 +94,10 @@ class AddUserCommandTest extends KernelTestCase
 
     /**
      * This helper method abstracts the boilerplate code needed to test the
-     * execution of a command. When the command is executed non-interactively,
-     * all its arguments are passed in $arguments. If some needed argument is
-     * missing, the command will ask for it interactively. Use the $inputs
-     * argument to define the answers to provide to the command.
+     * execution of a command.
+     *
+     * @param  array  $arguments All the arguments passed when executing the command
+     * @param  array  $inputs    The (optional) answers given to the command when it asks for the value of the missing arguments
      */
     private function executeCommand(array $arguments, array $inputs = [])
     {

--- a/tests/AppBundle/Command/AddUserCommandTest.php
+++ b/tests/AppBundle/Command/AddUserCommandTest.php
@@ -19,7 +19,87 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class AddUserCommandTest extends KernelTestCase
 {
-    private function executeCommand(array $inputArgs, array $interactiveInputs = [])
+    private $userData = [
+        'username' => 'chuck_norris',
+        'password' => 'foobar',
+        'email' => 'chuck@norris.com',
+        'full-name' => 'Chuck Norris',
+    ];
+
+    /**
+     * @dataProvider isAdminDataProvider
+     *
+     * This test provides all the arguments required by the command, so the
+     * command runs non-interactively and it won't ask for any argument.
+     */
+    public function testCreateUserNonInteractive($isAdmin)
+    {
+        $input = $this->userData;
+        if ($isAdmin) {
+            $input['--admin'] = 1;
+        }
+        $this->executeCommand($input);
+
+        $this->assertUserCreated($isAdmin);
+    }
+
+    /**
+     * @dataProvider isAdminDataProvider
+     *
+     * This test doesn't provide all the arguments required by the command, so
+     * the command runs interactively and it will ask for the value of the missing
+     * arguments.
+     * See https://symfony.com/doc/current/components/console/helpers/questionhelper.html#testing-a-command-that-expects-input
+     */
+    public function testCreateUserInteractive($isAdmin)
+    {
+        $this->executeCommand(
+            // these are the arguments (only 1 is passed, the rest are missing)
+            $isAdmin ? ['--admin' => 1] : [],
+            // these are the responses given to the questions asked by the command
+            // to get the value of the missing required arguments
+            array_values($this->userdata)
+        );
+
+        $this->assertUserCreated($isAdmin);
+    }
+
+    /**
+     * This is used to execute the same test twice: first for normal users
+     * (isAdmin = false) and then for admin users (isAdmin = true).
+     */
+    public function isAdminDataProvider()
+    {
+        yield [false];
+        yield [true];
+    }
+
+    /**
+     * This helper method checks that the user was correctly created and saved
+     * it in the database.
+     */
+    private function assertUserCreated($isAdmin)
+    {
+        $container = self::$kernel->getContainer();
+
+        /** @var User $user */
+        $user = $container->get('doctrine')->getRepository(User::class)->findOneByEmail($this->userData['email']);
+        $this->assertNotNull($user);
+
+        $this->assertSame($this->userData['full-name'], $user->getFullName());
+        $this->assertSame($this->userData['username'], $user->getUsername());
+        $this->assertTrue($container->get('security.password_encoder')->isPasswordValid($user, $this->userData['password']));
+        $this->assertSame($isAdmin ? ['ROLE_ADMIN'] : ['ROLE_USER'], $user->getRoles());
+    }
+
+    /**
+     * This helper method abstracts the boilerplate code needed to test the
+     * execution of a command. When the command is executed non-interactively,
+     * all its arguments are passed in $arguments. If some needed argument is
+     * missing, the command will ask for it interactively. Use the $inputs
+     * argument to define the answers to provide to the command.
+     */
+    private function executeCommand(array $arguments, array $inputs = [])
     {
         self::bootKernel();
 
@@ -27,69 +107,7 @@ class AddUserCommandTest extends KernelTestCase
         $command->setApplication(new Application(self::$kernel));
 
         $commandTester = new CommandTester($command);
-        $commandTester->setInputs($interactiveInputs);
-        $commandTester->execute($inputArgs);
-    }
-
-    /**
-     * @param bool $isAdmin
-     */
-    private function assertUserCreated($isAdmin)
-    {
-        $container = self::$kernel->getContainer();
-
-        /** @var User $user */
-        $user = $container->get('doctrine')->getRepository(User::class)->findOneByEmail('chuck@norris.com');
-        $this->assertNotNull($user);
-
-        $this->assertSame('Chuck Norris', $user->getFullName());
-        $this->assertSame('chuck_norris', $user->getUsername());
-        $this->assertTrue($container->get('security.password_encoder')->isPasswordValid($user, 'foobar'));
-        $this->assertSame($isAdmin ? ['ROLE_ADMIN'] : ['ROLE_USER'], $user->getRoles());
-    }
-
-    /**
-     * @dataProvider isAdminDataProvider
-     *
-     * @param bool $isAdmin
-     */
-    public function testCreateUserNonInteractive($isAdmin)
-    {
-        $input = [
-            'username' => 'chuck_norris',
-            'password' => 'foobar',
-            'email' => 'chuck@norris.com',
-            'full-name' => 'Chuck Norris',
-        ];
-
-        if ($isAdmin) {
-            $input['--admin'] = 1;
-        }
-
-        $this->executeCommand($input);
-        $this->assertUserCreated($isAdmin);
-    }
-
-    /**
-     * @dataProvider isAdminDataProvider
-     *
-     * @param bool $isAdmin
-     */
-    public function testCreateUserInteractive($isAdmin)
-    {
-        // see https://symfony.com/doc/current/components/console/helpers/questionhelper.html#testing-a-command-that-expects-input
-        $this->executeCommand($isAdmin ? ['--admin' => 1] : [], [
-            'chuck_norris',
-            'foobar',
-            'chuck@norris.com',
-            'Chuck Norris',
-        ]);
-        $this->assertUserCreated($isAdmin);
-    }
-
-    public function isAdminDataProvider()
-    {
-        yield [true];
-        yield [false];
+        $commandTester->setInputs($inputs);
+        $commandTester->execute($arguments);
     }
 }

--- a/tests/AppBundle/Command/AddUserCommandTest.php
+++ b/tests/AppBundle/Command/AddUserCommandTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Command;
+
+use AppBundle\Command\AddUserCommand;
+use AppBundle\Entity\User;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class AddUserCommandTest extends KernelTestCase
+{
+    private function executeCommand(array $inputArgs, array $interactiveInputs = [])
+    {
+        self::bootKernel();
+
+        $command = new AddUserCommand();
+        $command->setApplication(new Application(self::$kernel));
+
+        $commandTester = new CommandTester($command);
+        $commandTester->setInputs($interactiveInputs);
+        $commandTester->execute($inputArgs);
+    }
+
+    /**
+     * @param bool $isAdmin
+     */
+    private function assertUserCreated($isAdmin)
+    {
+        $container = self::$kernel->getContainer();
+
+        /** @var User $user */
+        $user = $container->get('doctrine')->getRepository(User::class)->findOneByEmail('chuck@norris.com');
+        $this->assertNotNull($user);
+
+        $this->assertSame('Chuck Norris', $user->getFullName());
+        $this->assertSame('chuck_norris', $user->getUsername());
+        $this->assertTrue($container->get('security.password_encoder')->isPasswordValid($user, 'foobar'));
+        $this->assertSame($isAdmin ? ['ROLE_ADMIN'] : ['ROLE_USER'], $user->getRoles());
+    }
+
+    /**
+     * @dataProvider isAdminDataProvider
+     *
+     * @param bool $isAdmin
+     */
+    public function testCreateUserNonInteractive($isAdmin)
+    {
+        $input = [
+            'username' => 'chuck_norris',
+            'password' => 'foobar',
+            'email' => 'chuck@norris.com',
+            'full-name' => 'Chuck Norris',
+        ];
+
+        if ($isAdmin) {
+            $input['--admin'] = 1;
+        }
+
+        $this->executeCommand($input);
+        $this->assertUserCreated($isAdmin);
+    }
+
+    /**
+     * @dataProvider isAdminDataProvider
+     *
+     * @param bool $isAdmin
+     */
+    public function testCreateUserInteractive($isAdmin)
+    {
+        // see https://symfony.com/doc/current/components/console/helpers/questionhelper.html#testing-a-command-that-expects-input
+        $this->executeCommand($isAdmin ? ['--admin' => 1] : [], [
+            'chuck_norris',
+            'foobar',
+            'chuck@norris.com',
+            'Chuck Norris',
+        ]);
+        $this->assertUserCreated($isAdmin);
+    }
+
+    public function isAdminDataProvider()
+    {
+        yield [true];
+        yield [false];
+    }
+}

--- a/tests/AppBundle/Command/AddUserCommandTest.php
+++ b/tests/AppBundle/Command/AddUserCommandTest.php
@@ -58,7 +58,7 @@ class AddUserCommandTest extends KernelTestCase
             $isAdmin ? ['--admin' => 1] : [],
             // these are the responses given to the questions asked by the command
             // to get the value of the missing required arguments
-            array_values($this->userdata)
+            array_values($this->userData)
         );
 
         $this->assertUserCreated($isAdmin);


### PR DESCRIPTION
This adds a simple test for `AddUserCommand` that creates a user non-interactively and interactively.

Fixes https://github.com/symfony/symfony-demo/issues/473.