### PR TITLE
Add missing validation message for Russian

### DIFF
--- a/app/Resources/translations/validators.ru.xlf
+++ b/app/Resources/translations/validators.ru.xlf
@@ -14,6 +14,10 @@
                 <source>post.too_short_content</source>
                 <target>Содержание записи слишком короткое (минимум {{ limit }} символов).</target>
             </trans-unit>
+            <trans-unit id="post.too_many_tags">
+                <source>post.too_many_tags</source>
+                <target>Слишком много тегов (добавьте {{ limit }} тегов или меньше)</target>
+            </trans-unit>
             <trans-unit id="comment.blank">
                 <source>comment.blank</source>
                 <target>Пожалуйста, не оставляйте текст комментария пустым!</target>


### PR DESCRIPTION
The `post.too_many_tags` key isn't translated