### PR TITLE
run tests against php 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
     - php: 5.5
     - php: 5.6
     - php: 7.0
+    - php: 7.1
     - php: hhvm
   allow_failures:
     - php: hhvm


### PR DESCRIPTION
Enable php 7.1 in travis-ci matrix.