### PR TITLE
Add a log example as suggested in #489

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -42,7 +42,7 @@ services:
 
     app.comment_notification:
         class: AppBundle\EventListener\CommentNotificationListener
-        arguments: ['@mailer', '@router', '@translator', '%app.notifications.email_sender%']
+        arguments: ['@mailer', '@router', '@translator', '%app.notifications.email_sender%', '@logger']
         # The "method" attribute of this tag is optional and defaults to "on + camelCasedEventName"
         # If the event is "comment.created" the method executed by default is "onCommentCreated()".
         tags:

--- a/src/AppBundle/EventListener/CommentNotificationListener.php
+++ b/src/AppBundle/EventListener/CommentNotificationListener.php
@@ -98,6 +98,6 @@ class CommentNotificationListener
         // Symfony comes with an outside library - called Monolog - that allows you to create logs
         // See http://symfony.com/doc/current/logging.html#logging-a-message
         $logger = $this->get('logger');
-        $logger->info('Comment created on ' . $linkToPost);
+        $logger->info('Comment created on '.$linkToPost);
     }
 }

--- a/src/AppBundle/EventListener/CommentNotificationListener.php
+++ b/src/AppBundle/EventListener/CommentNotificationListener.php
@@ -15,11 +15,13 @@ use AppBundle\Entity\Comment;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Translation\TranslatorInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Notifies post's author about new comments.
  *
  * @author Oleg Voronkovich <oleg-voronkovich@yandex.ru>
+ * @author Arnaud PETITPAS <arnaudpetitpas@protonmail.ch>
  */
 class CommentNotificationListener
 {
@@ -44,19 +46,26 @@ class CommentNotificationListener
     private $sender;
 
     /**
+    * @var LoggerInterface
+    */
+    private $logger;
+
+    /**
      * Constructor.
      *
      * @param \Swift_Mailer         $mailer
      * @param UrlGeneratorInterface $urlGenerator
      * @param TranslatorInterface   $translator
      * @param string                $sender
+     * @param LoggerInterface       $logger
      */
-    public function __construct(\Swift_Mailer $mailer, UrlGeneratorInterface $urlGenerator, TranslatorInterface $translator, $sender)
+    public function __construct(\Swift_Mailer $mailer, UrlGeneratorInterface $urlGenerator, TranslatorInterface $translator, $sender, LoggerInterface $logger)
     {
         $this->mailer = $mailer;
         $this->urlGenerator = $urlGenerator;
         $this->translator = $translator;
         $this->sender = $sender;
+        $this->logger = $logger;
     }
 
     /**
@@ -96,8 +105,9 @@ class CommentNotificationListener
         $this->mailer->send($message);
 
         // Symfony comes with an outside library - called Monolog - that allows you to create logs
-        // See http://symfony.com/doc/current/logging.html#logging-a-message
-        $logger = $this->get('logger');
-        $logger->info('Comment created on '.$linkToPost);
+        // Because we are in a service, the logger service need to be injected in the constructor
+        // We cannot use $logger = $this->get('logger') here.
+        // See http://symfony.com/doc/current/logging.html#using-a-logger-inside-a-service
+        $this->logger->info('New comment created - '.$linkToPost);
     }
 }

--- a/src/AppBundle/EventListener/CommentNotificationListener.php
+++ b/src/AppBundle/EventListener/CommentNotificationListener.php
@@ -94,5 +94,10 @@ class CommentNotificationListener
         // However, you can inspect the contents of those unsent emails using the debug toolbar.
         // See http://symfony.com/doc/current/email/dev_environment.html#viewing-from-the-web-debug-toolbar
         $this->mailer->send($message);
+
+        // Symfony comes with an outside library - called Monolog - that allows you to create logs
+        // See http://symfony.com/doc/current/logging.html#logging-a-message
+        $logger = $this->get('logger');
+        $logger->info('Comment created on ' . $linkToPost);
     }
 }

--- a/src/AppBundle/EventListener/CommentNotificationListener.php
+++ b/src/AppBundle/EventListener/CommentNotificationListener.php
@@ -12,10 +12,10 @@
 namespace AppBundle\EventListener;
 
 use AppBundle\Entity\Comment;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Translation\TranslatorInterface;
-use Psr\Log\LoggerInterface;
 
 /**
  * Notifies post's author about new comments.
@@ -46,8 +46,8 @@ class CommentNotificationListener
     private $sender;
 
     /**
-    * @var LoggerInterface
-    */
+     * @var LoggerInterface
+     */
     private $logger;
 
     /**


### PR DESCRIPTION
Add an example of how to use the logger service in `CommentNotificationListener` as suggested in #489.