### PR TITLE
Fixes a minor php cs error that prevents builds to pass

### DIFF
--- a/tests/AppBundle/Command/AddUserCommandTest.php
+++ b/tests/AppBundle/Command/AddUserCommandTest.php
@@ -96,8 +96,8 @@ class AddUserCommandTest extends KernelTestCase
      * This helper method abstracts the boilerplate code needed to test the
      * execution of a command.
      *
-     * @param  array  $arguments All the arguments passed when executing the command
-     * @param  array  $inputs    The (optional) answers given to the command when it asks for the value of the missing arguments
+     * @param array $arguments All the arguments passed when executing the command
+     * @param array $inputs    The (optional) answers given to the command when it asks for the value of the missing arguments
      */
     private function executeCommand(array $arguments, array $inputs = [])
     {


### PR DESCRIPTION
This minor php cs error was introduced by commit 774adca218e95d0a68f5ac1d41948dfd927899d2