### PR TITLE
Add "show" button on edit post

### DIFF
--- a/app/Resources/translations/messages.en.xlf
+++ b/app/Resources/translations/messages.en.xlf
@@ -101,6 +101,10 @@
                 <source>action.show</source>
                 <target>Show</target>
             </trans-unit>
+            <trans-unit id="action.show_post">
+                <source>action.show_post</source>
+                <target>Show post</target>
+            </trans-unit>
             <trans-unit id="action.show_code">
                 <source>action.show_code</source>
                 <target>Show code</target>

--- a/app/Resources/views/admin/blog/edit.html.twig
+++ b/app/Resources/views/admin/blog/edit.html.twig
@@ -13,6 +13,12 @@
 {% endblock %}
 
 {% block sidebar %}
+    <div class="section">
+        <a href="{{ path('admin_post_show', { id: post.id }) }}" class="btn btn-lg btn-block btn-success">
+            <i class="fa fa-eye" aria-hidden="true"></i> {{ 'action.show_post'|trans }}
+        </a>
+    </div>
+
     <div class="section actions">
         {{ include('admin/blog/_delete_form.html.twig', { post: post }, with_context = false) }}
     </div>


### PR DESCRIPTION
I propose to add a new button "show post" to review quickly the edited post, it avoid come back to post list for perform this common action.

I think it's more an ergonomic issue rather than a new feature.

**Preview:**

![show_btn](https://cloud.githubusercontent.com/assets/2028198/24167690/033a521c-0e4e-11e7-9962-1110c2b8b467.png)