### PR TITLE
Conform to Twig coding standards

### DIFF
--- a/app/Resources/views/admin/blog/_delete_form.html.twig
+++ b/app/Resources/views/admin/blog/_delete_form.html.twig
@@ -1,5 +1,5 @@
 {{ include('blog/_delete_post_confirmation.html.twig') }}
-<form action="{{ url('admin_post_delete', { id: post.id }) }}" method="post" data-confirmation="true" id="delete-form">
+<form action="{{ url('admin_post_delete', {id: post.id}) }}" method="post" data-confirmation="true" id="delete-form">
     <input type="hidden" name="token" value="{{ csrf_token('delete') }}" />
     <input type="submit" value="{{ 'action.delete_post'|trans }}" class="btn btn-lg btn-block btn-danger" />
 </form>

--- a/app/Resources/views/admin/blog/_form.html.twig
+++ b/app/Resources/views/admin/blog/_form.html.twig
@@ -3,7 +3,7 @@
     test the server-side validation errors from the browser. To temporarily
     disable this validation, add the 'novalidate' attribute:
 
-    {{ form_start(form, { attr: { novalidate: 'novalidate' } }) }}
+    {{ form_start(form, {attr: {novalidate: 'novalidate'}}) }}
 #}
 
 {% if show_confirmation|default(false) %}
@@ -11,7 +11,7 @@
     {{ include('blog/_delete_post_confirmation.html.twig') }}
 {% endif %}
 
-{{ form_start(form, { attr: attr|default({}) }) }}
+{{ form_start(form, {attr: attr|default({})}) }}
     {{ form_widget(form) }}
 
     <input type="submit" value="{{ button_label|default('label.create_post'|trans) }}"

--- a/app/Resources/views/admin/blog/edit.html.twig
+++ b/app/Resources/views/admin/blog/edit.html.twig
@@ -14,13 +14,13 @@
 
 {% block sidebar %}
     <div class="section">
-        <a href="{{ path('admin_post_show', { id: post.id }) }}" class="btn btn-lg btn-block btn-success">
+        <a href="{{ path('admin_post_show', {id: post.id}) }}" class="btn btn-lg btn-block btn-success">
             <i class="fa fa-eye" aria-hidden="true"></i> {{ 'action.show_post'|trans }}
         </a>
     </div>
 
     <div class="section actions">
-        {{ include('admin/blog/_delete_form.html.twig', { post: post }, with_context = false) }}
+        {{ include('admin/blog/_delete_form.html.twig', {post: post}, with_context = false) }}
     </div>
 
     {{ parent() }}

--- a/app/Resources/views/admin/blog/index.html.twig
+++ b/app/Resources/views/admin/blog/index.html.twig
@@ -23,11 +23,11 @@
                 <td>{{ post.publishedAt|localizeddate('medium', 'short', null, 'UTC') }}</td>
                 <td class="text-right">
                     <div class="item-actions">
-                        <a href="{{ path('admin_post_show', { id: post.id }) }}" class="btn btn-sm btn-default">
+                        <a href="{{ path('admin_post_show', {id: post.id}) }}" class="btn btn-sm btn-default">
                             {{ 'action.show'|trans }}
                         </a>
 
-                        <a href="{{ path('admin_post_edit', { id: post.id }) }}" class="btn btn-sm btn-primary">
+                        <a href="{{ path('admin_post_edit', {id: post.id}) }}" class="btn btn-sm btn-primary">
                             <i class="fa fa-edit" aria-hidden="true"></i> {{ 'action.edit'|trans }}
                         </a>
                     </div>

--- a/app/Resources/views/admin/blog/new.html.twig
+++ b/app/Resources/views/admin/blog/new.html.twig
@@ -13,7 +13,7 @@
         {{ form_row(form.tags) }}
 
         <input type="submit" value="{{ 'label.create_post'|trans }}" class="btn btn-primary" />
-        {{ form_widget(form.saveAndCreateNew, { label: 'label.save_and_create_new', attr: { class: 'btn btn-primary' } }) }}
+        {{ form_widget(form.saveAndCreateNew, {label: 'label.save_and_create_new', attr: {class: 'btn btn-primary'}}) }}
         <a href="{{ path('admin_post_index') }}" class="btn btn-link">
             {{ 'action.back_to_list'|trans }}
         </a>

--- a/app/Resources/views/admin/blog/show.html.twig
+++ b/app/Resources/views/admin/blog/show.html.twig
@@ -21,13 +21,13 @@
 
 {% block sidebar %}
     <div class="section">
-        <a href="{{ path('admin_post_edit', { id: post.id }) }}" class="btn btn-lg btn-block btn-success">
+        <a href="{{ path('admin_post_edit', {id: post.id}) }}" class="btn btn-lg btn-block btn-success">
             <i class="fa fa-edit" aria-hidden="true"></i> {{ 'action.edit_contents'|trans }}
         </a>
     </div>
 
     <div class="section">
-        {{ include('admin/blog/_delete_form.html.twig', { post: post }, with_context = false) }}
+        {{ include('admin/blog/_delete_form.html.twig', {post: post}, with_context = false) }}
     </div>
 
     {{ parent() }}

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -77,7 +77,7 @@
                                     </a>
                                     <ul class="dropdown-menu locales" role="menu" aria-labelledby="locales">
                                         {% for locale in locales() %}
-                                            <li {% if app.request.locale == locale.code %}aria-checked="true" class="active"{%else%}aria-checked="false"{% endif %} role="menuitem"><a href="{{ path(app.request.get('_route', 'blog_index'), app.request.get('_route_params', [])|merge({ _locale: locale.code })) }}">{{ locale.name|capitalize }}</a></li>
+                                            <li {% if app.request.locale == locale.code %}aria-checked="true" class="active"{% else %}aria-checked="false"{% endif %} role="menuitem"><a href="{{ path(app.request.get('_route', 'blog_index'), app.request.get('_route_params', [])|merge({_locale: locale.code})) }}">{{ locale.name|capitalize }}</a></li>
                                         {% endfor %}
                                     </ul>
                                 </li>

--- a/app/Resources/views/blog/_comment_form.html.twig
+++ b/app/Resources/views/blog/_comment_form.html.twig
@@ -3,10 +3,10 @@
     test the server-side validation errors from the browser. To temporarily
     disable this validation, add the 'novalidate' attribute:
 
-    {{ form_start(form, { method: ..., action: ..., attr: { novalidate: 'novalidate' } }) }}
+    {{ form_start(form, {method: ..., action: ..., attr: {novalidate: 'novalidate'}}) }}
 #}
 
-{{ form_start(form, { method: 'POST', action: path('comment_new', { 'postSlug': post.slug }) }) }}
+{{ form_start(form, {method: 'POST', action: path('comment_new', {'postSlug': post.slug})}) }}
     {#  instead of displaying form fields one by one, you can also display them
         all with their default options and styles just by calling to this function:
 
@@ -20,12 +20,12 @@
         {{ form_errors(form) }}
 
         <div class="form-group {% if not form.content.vars.valid %}has-error{% endif %}">
-            {{ form_label(form.content, 'label.content', { label_attr: { class: 'hidden' }}) }}
+            {{ form_label(form.content, 'label.content', {label_attr: {class: 'hidden'}}) }}
 
             {# Render any errors for the "content" field (e.g. when a class property constraint failed) #}
             {{ form_errors(form.content) }}
 
-            {{ form_widget(form.content, { attr: { rows: 10 } }) }}
+            {{ form_widget(form.content, {attr: {rows: 10}}) }}
         </div>
 
         <div class="form-group">

--- a/app/Resources/views/blog/index.html.twig
+++ b/app/Resources/views/blog/index.html.twig
@@ -6,7 +6,7 @@
     {% for post in posts %}
         <article class="post">
             <h2>
-                <a href="{{ path('blog_post', { slug: post.slug }) }}">
+                <a href="{{ path('blog_post', {slug: post.slug}) }}">
                     {{ post.title }}
                 </a>
             </h2>
@@ -26,7 +26,7 @@
 
     {% if posts.haveToPaginate %}
         <div class="navigation text-center">
-            {{ pagerfanta(posts, 'twitter_bootstrap3_translated', { routeName: 'blog_index_paginated' }) }}
+            {{ pagerfanta(posts, 'twitter_bootstrap3_translated', {routeName: 'blog_index_paginated'}) }}
         </div>
     {% endif %}
 {% endblock %}

--- a/app/Resources/views/blog/post_show.html.twig
+++ b/app/Resources/views/blog/post_show.html.twig
@@ -22,7 +22,7 @@
         See http://symfony.com/doc/current/cookbook/security/remember_me.html#forcing-the-user-to-re-authenticate-before-accessing-certain-resources
         #}
         {% if is_granted('IS_AUTHENTICATED_FULLY') %}
-            {{ render(controller('AppBundle:Blog:commentForm', { 'id': post.id })) }}
+            {{ render(controller('AppBundle:Blog:commentForm', {'id': post.id})) }}
         {% else %}
             <p>
                 <a class="btn btn-success" href="{{ path('security_login') }}">
@@ -59,7 +59,7 @@
 {% block sidebar %}
     {% if is_granted('edit', post) %}
         <div class="section">
-            <a class="btn btn-lg btn-block btn-success" href="{{ path('admin_post_edit', { id: post.id }) }}">
+            <a class="btn btn-lg btn-block btn-success" href="{{ path('admin_post_edit', {id: post.id}) }}">
                 <i class="fa fa-edit" aria-hidden="true"></i> {{ 'action.edit_post'|trans }}
             </a>
         </div>


### PR DESCRIPTION
See http://twig.sensiolabs.org/doc/2.x/coding_standards.html:

> Do not put any spaces before and after the opening and the closing of arrays and hashes.

> Put one (and only one) space after the start of a delimiter ({{, {%, and {#) and before the end of a delimiter (}}, %}, and #})

I changed a `{%else%}` to `{% else %}` on this point.