### PR TITLE
Prevent affecting some styles on the right sidebar

### DIFF
--- a/web/css/main.css
+++ b/web/css/main.css
@@ -224,8 +224,8 @@ body#login #login-users-help p .console {
 
 /* Page: 'Blog index'
    ------------------------------------------------------------------------- */
-body#blog_index h1,
-body#blog_index p {
+body#blog_index #main h1,
+body#blog_index #main p {
     margin-bottom: 0.5em
 }
 
@@ -248,7 +248,7 @@ body#blog_index .post-tags .label-default i {
 
 /* Page: 'Blog post show'
    ------------------------------------------------------------------------- */
-body#blog_post_show h3 {
+body#blog_post_show #main h3 {
     margin-bottom: 0.75em
 }
 


### PR DESCRIPTION
Before, some styles like margin also were applied to the right sidebar elements like `p`, `h3` tags.