### PR TITLE
Add a command that checks for missing translations in foreign language files

### DIFF
--- a/src/AppBundle/Command/CheckTranslationsCommand.php
+++ b/src/AppBundle/Command/CheckTranslationsCommand.php
@@ -1,0 +1,149 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AppBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Translation\DataCollectorTranslator;
+
+/**
+ * Class CheckTranslationsCommand
+ * @package AppBundle\Command
+ */
+class CheckTranslationsCommand extends ContainerAwareCommand
+{
+    /**
+     * This command uses the SymfonyStyle class which has a lot of helpful methods
+     * to style the console output, including tables and progress bars.
+     * @see http://symfony.com/doc/current/console/style.html
+     * @see http://api.symfony.com/3.2/Symfony/Component/Console/Style/SymfonyStyle.html
+     * @var SymfonyStyle
+     */
+    private $io = null;
+
+    /**
+     * @var DataCollectorTranslator
+     */
+    private $translator;
+
+    private $locales = [];
+
+    private $fallbackLocale = '';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('app:check-translations')
+            ->setDescription('Check translation files against the default translation file.')
+            ->addArgument('locale', InputArgument::OPTIONAL, 'The locale to check');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function initialize(InputInterface $input, OutputInterface $output)
+    {
+        $this->locales        = explode('|', $this->getContainer()->getParameter('app_locales'));
+        $this->fallbackLocale = 'en';
+        $this->translator     = $this->getContainer()->get('translator');
+        $this->io             = new SymfonyStyle($input, $output);
+
+        $this->translator->setLocale($this->fallbackLocale);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->io->title('Check translation files');
+
+        $locale = $input->getArgument('locale');
+
+        if ($locale) {
+            if (false == in_array($locale, $this->locales)) {
+                throw new \UnexpectedValueException(
+                    ' The given locale does not exist. Valid locale: '.implode(', ', $this->locales)
+                );
+            }
+            $this->check($locale);
+        } else {
+            $this->checkAll();
+        }
+    }
+
+    private function checkAll()
+    {
+        $fallbackMessages = $this->translator->getCatalogue()->all();
+
+        $checks = [];
+
+        foreach ($this->locales as $locale) {
+            if ($locale == $this->fallbackLocale) {
+                continue;
+            }
+
+            $check = [];
+
+            $check['Locale']      = $locale;
+            $check['Missing']     = 0;
+            $check['Superfluous'] = 0;
+
+            $catalogue = $this->translator->getCatalogue($locale)->all();
+
+            foreach ($catalogue as $domain => $messages) {
+                $check['Missing']     += count(array_diff_key($fallbackMessages[$domain], $messages));
+                $check['Superfluous'] += count(array_diff_key($messages, $fallbackMessages[$domain]));
+            }
+
+            $checks[] = $check;
+        }
+
+        $this->io->text(sprintf('Fallback locale: <info>%s</info>', $this->fallbackLocale));
+        $this->io->table(array_keys($checks[0]), $checks);
+    }
+
+    private function check($locale)
+    {
+        $fallbackMessages = $this->translator->getCatalogue()->all();
+        $localeMessages   = $this->translator->getCatalogue($locale)->all();
+
+        $missingStrings = [];
+
+        foreach ($fallbackMessages as $domain => $messages) {
+            if (false == array_key_exists($domain, $localeMessages)) {
+                $this->io->error(sprintf('The domain "%s" does not exist for locales "%s"', $domain, $locale));
+                continue;
+            }
+            $diff = array_diff_key($messages, $localeMessages[$domain]);
+            foreach ($diff as $key => $fallback) {
+                $missingStrings[] = [$domain, $key, $fallback];
+            }
+        }
+
+        $this->io->text(sprintf('Checking locale: <info>%s</info>', $locale));
+        $this->io->text(sprintf('Fallback locale: <info>%s</info>', $this->fallbackLocale));
+
+        if ($missingStrings) {
+            $this->io->text(sprintf('Missing strings: <info>%d</info>', count($missingStrings)));
+            $this->io->table(['Domain', 'Key', 'Fallback Message'], $missingStrings);
+        } else {
+            $this->io->success('Everything is translated.');
+        }
+    }
+}

--- a/src/AppBundle/Command/CheckTranslationsCommand.php
+++ b/src/AppBundle/Command/CheckTranslationsCommand.php
@@ -19,16 +19,17 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Translation\DataCollectorTranslator;
 
 /**
- * Class CheckTranslationsCommand
- * @package AppBundle\Command
+ * Class CheckTranslationsCommand.
  */
 class CheckTranslationsCommand extends ContainerAwareCommand
 {
     /**
      * This command uses the SymfonyStyle class which has a lot of helpful methods
      * to style the console output, including tables and progress bars.
+     *
      * @see http://symfony.com/doc/current/console/style.html
      * @see http://api.symfony.com/3.2/Symfony/Component/Console/Style/SymfonyStyle.html
+     *
      * @var SymfonyStyle
      */
     private $io = null;
@@ -58,10 +59,10 @@ class CheckTranslationsCommand extends ContainerAwareCommand
      */
     protected function initialize(InputInterface $input, OutputInterface $output)
     {
-        $this->locales        = explode('|', $this->getContainer()->getParameter('app_locales'));
+        $this->locales = explode('|', $this->getContainer()->getParameter('app_locales'));
         $this->fallbackLocale = 'en';
-        $this->translator     = $this->getContainer()->get('translator');
-        $this->io             = new SymfonyStyle($input, $output);
+        $this->translator = $this->getContainer()->get('translator');
+        $this->io = new SymfonyStyle($input, $output);
 
         $this->translator->setLocale($this->fallbackLocale);
     }
@@ -76,7 +77,7 @@ class CheckTranslationsCommand extends ContainerAwareCommand
         $locale = $input->getArgument('locale');
 
         if ($locale) {
-            if (false == in_array($locale, $this->locales)) {
+            if (false === in_array($locale, $this->locales)) {
                 throw new \UnexpectedValueException(
                     ' The given locale does not exist. Valid locale: '.implode(', ', $this->locales)
                 );
@@ -94,20 +95,20 @@ class CheckTranslationsCommand extends ContainerAwareCommand
         $checks = [];
 
         foreach ($this->locales as $locale) {
-            if ($locale == $this->fallbackLocale) {
+            if ($locale === $this->fallbackLocale) {
                 continue;
             }
 
             $check = [];
 
-            $check['Locale']      = $locale;
-            $check['Missing']     = 0;
+            $check['Locale'] = $locale;
+            $check['Missing'] = 0;
             $check['Superfluous'] = 0;
 
             $catalogue = $this->translator->getCatalogue($locale)->all();
 
             foreach ($catalogue as $domain => $messages) {
-                $check['Missing']     += count(array_diff_key($fallbackMessages[$domain], $messages));
+                $check['Missing'] += count(array_diff_key($fallbackMessages[$domain], $messages));
                 $check['Superfluous'] += count(array_diff_key($messages, $fallbackMessages[$domain]));
             }
 
@@ -121,12 +122,12 @@ class CheckTranslationsCommand extends ContainerAwareCommand
     private function check($locale)
     {
         $fallbackMessages = $this->translator->getCatalogue()->all();
-        $localeMessages   = $this->translator->getCatalogue($locale)->all();
+        $localeMessages = $this->translator->getCatalogue($locale)->all();
 
         $missingStrings = [];
 
         foreach ($fallbackMessages as $domain => $messages) {
-            if (false == array_key_exists($domain, $localeMessages)) {
+            if (false === array_key_exists($domain, $localeMessages)) {
                 $this->io->error(sprintf('The domain "%s" does not exist for locales "%s"', $domain, $locale));
                 continue;
             }


### PR DESCRIPTION
This will add a command that checks foreign language translation files for missing strings.

Executing the command without arguments checks all language files:

![2017-04-11-133404_1366x768_scrot](https://cloud.githubusercontent.com/assets/33978/24928940/d32fed48-1ec9-11e7-8903-d409160ef9b4.png)

Providing a locale parameter only files for this locale will be checked and untranslated keys are displayed along with their fallback message.

![2017-04-11-133508_1366x768_scrot](https://cloud.githubusercontent.com/assets/33978/24929277/059fb578-1ecb-11e7-8b1c-8c52584fa034.png)

If everything is translated a `<success>` message will be displayed.

![2017-04-11-134342_1366x768_scrot](https://cloud.githubusercontent.com/assets/33978/24928942/d3365192-1ec9-11e7-8a30-05692a8aed6b.png)

This command is using the [`SymfonyStyle`](http://symfony.com/doc/current/console/style.html) class to style the console output using the "Symfony style guide". I believe that also the other console commands should use this class to ensure a uniform display.
