### PR TITLE
Remove title.login_help translation which is unused

### DIFF
--- a/app/Resources/translations/messages.ca.xlf
+++ b/app/Resources/translations/messages.ca.xlf
@@ -35,10 +35,6 @@
                 <source>title.twig_template_code</source>
                 <target>Codi de la plantilla Twig</target>
             </trans-unit>
-            <trans-unit id="title.login_help">
-                <source>title.login_help</source>
-                <target>Prova qualsevol dels següents usuaris</target>
-            </trans-unit>
             <trans-unit id="title.login">
                 <source>title.login</source>
                 <target>Accés segur</target>

--- a/app/Resources/translations/messages.de.xlf
+++ b/app/Resources/translations/messages.de.xlf
@@ -336,10 +336,6 @@
                 <source>http_error_500.suggestion</source>
                 <target><![CDATA[Versuche diese Seite in einigen Minuten erneut zu laden oder <a href="%url%">gehe zurück zur Homepage</a>.]]></target>
             </trans-unit>
-            <trans-unit id="title.login_help">
-                <source>title.login_help</source>
-                <target>Versuche einen der folgenden Benutzer</target>
-            </trans-unit>
             <trans-unit id="notification.comment_created">
                 <source>notification.comment_created</source>
                 <target>Dein Beitrag hat einen Kommentar erhalten!</target>

--- a/app/Resources/translations/messages.en.xlf
+++ b/app/Resources/translations/messages.en.xlf
@@ -72,10 +72,6 @@
                 <source>title.twig_template_code</source>
                 <target>Twig template code</target>
             </trans-unit>
-            <trans-unit id="title.login_help">
-                <source>title.login_help</source>
-                <target>Try either of the following users</target>
-            </trans-unit>
             <trans-unit id="title.login">
                 <source>title.login</source>
                 <target>Secure Sign in</target>

--- a/app/Resources/translations/messages.es.xlf
+++ b/app/Resources/translations/messages.es.xlf
@@ -72,10 +72,6 @@
                 <source>title.twig_template_code</source>
                 <target>Código de la plantilla Twig</target>
             </trans-unit>
-            <trans-unit id="title.login_help">
-                <source>title.login_help</source>
-                <target>Prueba cualquiera de los siguientes usuarios</target>
-            </trans-unit>
             <trans-unit id="title.login">
                 <source>title.login</source>
                 <target>Acceso seguro</target>

--- a/app/Resources/translations/messages.fr.xlf
+++ b/app/Resources/translations/messages.fr.xlf
@@ -72,10 +72,6 @@
                 <source>title.twig_template_code</source>
                 <target>Code du template Twig</target>
             </trans-unit>
-            <trans-unit id="title.login_help">
-                <source>title.login_help</source>
-                <target>Essayez avec l'un des utilisateurs suivants</target>
-            </trans-unit>
             <trans-unit id="title.login">
                 <source>title.login</source>
                 <target>Connexion sécurisée</target>

--- a/app/Resources/translations/messages.it.xlf
+++ b/app/Resources/translations/messages.it.xlf
@@ -72,10 +72,6 @@
                 <source>title.twig_template_code</source>
                 <target>Codice del template Twig</target>
             </trans-unit>
-            <trans-unit id="title.login_help">
-                <source>title.login_help</source>
-                <target>Provare uno dei seguenti utenti</target>
-            </trans-unit>
             <trans-unit id="title.login">
                 <source>title.login</source>
                 <target>Accesso sicuro</target>


### PR DESCRIPTION
Actually, we have the same translation message for `help.login_users` key