### PR TITLE
Rename .php_cs to .php_cs.dist as a best practise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /app/config/parameters.yml
 /build/
 /phpunit.xml
+/.php_cs
 /var/*
 !/var/cache
 /var/cache/*

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,4 +1,3 @@
-#!/usr/bin/env php
 <?php
 
 $fileHeaderComment = <<<COMMENT


### PR DESCRIPTION
Hello,

Everything is in the title.

I also removed the shebang because it looked useless, let me know if I am wrong :-)