### PR TITLE
RFC: Always enforce updating inverse side for Comment

### DIFF
--- a/src/AppBundle/Entity/Post.php
+++ b/src/AppBundle/Entity/Post.php
@@ -203,17 +203,16 @@ class Post
 
     public function addComment(Comment $comment)
     {
+        $comment->setPost($this);
         if (!$this->comments->contains($comment)) {
             $this->comments->add($comment);
-            $comment->setPost($this);
         }
     }
 
     public function removeComment(Comment $comment)
     {
-        if ($this->comments->removeElement($comment)) {
-            $comment->setPost(null);
-        }
+        $comment->setPost(null);
+        $this->comments->removeElement($comment);
     }
 
     public function getSummary()


### PR DESCRIPTION
It's an edge case, but what do you think about always updating inverse side in adder/remover methods?

For example, currently this code won't update inverse side properly:
```php
$comment = new Comment();
$post->getComments()->add($comment);
// but then if we will call adder method
$post->addComment($comment); // Comment::$post is still equals null here due to the failed `!contains()` check in it
```