### PR TITLE
Removed HHVM from Travis CI test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,16 +12,9 @@ matrix:
     - php: 5.6
     - php: 7.0
     - php: 7.1
-    # Use the newer stack for HHVM as HHVM does not support Precise anymore since a long time and so Precise has an outdated version
-    - php: hhvm
-      sudo: required
-      dist: trusty
-      group: edge
-  allow_failures:
-    - php: hhvm
 
 before_install:
-  - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi
+  - phpenv config-rm xdebug.ini
   - composer self-update
 
 install:


### PR DESCRIPTION
Following the decision of Symfony to drop HHVM support.