### PR TITLE
Use Symfony console style

### DIFF
--- a/src/AppBundle/Command/AddUserCommand.php
+++ b/src/AppBundle/Command/AddUserCommand.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * A command console that creates users and stores them in the database.
@@ -97,34 +98,28 @@ class AddUserCommand extends ContainerAwareCommand
             return;
         }
 
-        // multi-line messages can be displayed this way...
-        $output->writeln('');
-        $output->writeln('Add User Command Interactive Wizard');
-        $output->writeln('-----------------------------------');
+        // See: http://symfony.com/doc/current/console/style.html
+        $io = new SymfonyStyle($input, $output);
 
-        // ...but you can also pass an array of strings to the writeln() method
-        $output->writeln([
-            '',
-            'If you prefer to not use this interactive wizard, provide the',
-            'arguments required by this command as follows:',
+        // Use the title() method to display the title
+        $io->title('Add User Command Interactive Wizard');
+
+        // multi-line messages can be displayed this way...
+        $io->text('If you prefer to not use this interactive wizard, provide the');
+        $io->text('arguments required by this command as follows:');
+
+        // ...but you can also pass an array of strings to the text() method
+        $io->text([
             '',
             ' $ php bin/console app:add-user username password email@example.com',
             '',
-        ]);
-
-        $output->writeln([
-            '',
             'Now we\'ll ask you for the value of all the missing command arguments.',
-            '',
         ]);
-
-        // See https://symfony.com/doc/current/components/console/helpers/questionhelper.html
-        $console = $this->getHelper('question');
 
         // Ask for the username if it's not defined
         $username = $input->getArgument('username');
         if (null === $username) {
-            $question = new Question(' > <info>Username</info>: ');
+            $question = new Question('Username');
             $question->setValidator(function ($answer) {
                 if (empty($answer)) {
                     throw new \RuntimeException('The username cannot be empty');
@@ -134,50 +129,50 @@ class AddUserCommand extends ContainerAwareCommand
             });
             $question->setMaxAttempts(self::MAX_ATTEMPTS);
 
-            $username = $console->ask($input, $output, $question);
+            $username = $io->askQuestion($question);
             $input->setArgument('username', $username);
         } else {
-            $output->writeln(' > <info>Username</info>: '.$username);
+            $io->text(' > <info>Username</info>: '.$username);
         }
 
         // Ask for the password if it's not defined
         $password = $input->getArgument('password');
         if (null === $password) {
-            $question = new Question(' > <info>Password</info> (your type will be hidden): ');
+            $question = new Question('Password (your type will be hidden)');
             $question->setValidator([$this, 'passwordValidator']);
             $question->setHidden(true);
             $question->setMaxAttempts(self::MAX_ATTEMPTS);
 
-            $password = $console->ask($input, $output, $question);
+            $password = $io->askQuestion($question);
             $input->setArgument('password', $password);
         } else {
-            $output->writeln(' > <info>Password</info>: '.str_repeat('*', mb_strlen($password)));
+            $io->text(' > <info>Password</info>: '.str_repeat('*', mb_strlen($password)));
         }
 
         // Ask for the email if it's not defined
         $email = $input->getArgument('email');
         if (null === $email) {
-            $question = new Question(' > <info>Email</info>: ');
+            $question = new Question('Email');
             $question->setValidator([$this, 'emailValidator']);
             $question->setMaxAttempts(self::MAX_ATTEMPTS);
 
-            $email = $console->ask($input, $output, $question);
+            $email = $io->askQuestion($question);
             $input->setArgument('email', $email);
         } else {
-            $output->writeln(' > <info>Email</info>: '.$email);
+            $io->text(' > <info>Email</info>: '.$email);
         }
 
         // Ask for the full name if it's not defined
         $fullName = $input->getArgument('full-name');
         if (null === $fullName) {
-            $question = new Question(' > <info>Full Name</info>: ');
+            $question = new Question('Full Name');
             $question->setValidator([$this, 'fullNameValidator']);
             $question->setMaxAttempts(self::MAX_ATTEMPTS);
 
-            $fullName = $console->ask($input, $output, $question);
+            $fullName = $io->askQuestion($question);
             $input->setArgument('full-name', $fullName);
         } else {
-            $output->writeln(' > <info>Full Name</info>: '.$fullName);
+            $io->text(' > <info>Full Name</info>: '.$fullName);
         }
     }
 
@@ -188,6 +183,7 @@ class AddUserCommand extends ContainerAwareCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $startTime = microtime(true);
+        $io = new SymfonyStyle($input, $output);
 
         $username = $input->getArgument('username');
         $plainPassword = $input->getArgument('password');
@@ -213,14 +209,13 @@ class AddUserCommand extends ContainerAwareCommand
         $this->entityManager->persist($user);
         $this->entityManager->flush();
 
-        $output->writeln('');
-        $output->writeln(sprintf('[OK] %s was successfully created: %s (%s)', $isAdmin ? 'Administrator user' : 'User', $user->getUsername(), $user->getEmail()));
+        $io->success(sprintf('%s was successfully created: %s (%s)', $isAdmin ? 'Administrator user' : 'User', $user->getUsername(), $user->getEmail()));
 
         if ($output->isVerbose()) {
             $finishTime = microtime(true);
             $elapsedTime = $finishTime - $startTime;
 
-            $output->writeln(sprintf('[INFO] New user database id: %d / Elapsed time: %.2f ms', $user->getId(), $elapsedTime * 1000));
+            $io->note(sprintf('New user database id: %d / Elapsed time: %.2f ms', $user->getId(), $elapsedTime * 1000));
         }
     }
 

--- a/src/AppBundle/Command/DeleteUserCommand.php
+++ b/src/AppBundle/Command/DeleteUserCommand.php
@@ -18,6 +18,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * A command console that deletes users from the database.
@@ -78,32 +79,27 @@ HELP
             return;
         }
 
-        $output->writeln('');
-        $output->writeln('Delete User Command Interactive Wizard');
-        $output->writeln('-----------------------------------');
+        // See: http://symfony.com/doc/current/console/style.html
+        $io = new SymfonyStyle($input, $output);
 
-        $output->writeln([
-            '',
+
+        $io->title('Delete User Command Interactive Wizard');
+
+        $io->text([
             'If you prefer to not use this interactive wizard, provide the',
             'arguments required by this command as follows:',
             '',
             ' $ php bin/console app:delete-user username',
             '',
-        ]);
-
-        $output->writeln([
-            '',
             'Now we\'ll ask you for the value of all the missing command arguments.',
             '',
         ]);
-
-        $helper = $this->getHelper('question');
 
         $question = new Question(' > <info>Username</info>: ');
         $question->setValidator([$this, 'usernameValidator']);
         $question->setMaxAttempts(self::MAX_ATTEMPTS);
 
-        $username = $helper->ask($input, $output, $question);
+        $username = $io->askQuestion($question);
         $input->setArgument('username', $username);
     }
 
@@ -128,8 +124,8 @@ HELP
         $this->entityManager->remove($user);
         $this->entityManager->flush();
 
-        $output->writeln('');
-        $output->writeln(sprintf('[OK] User "%s" (ID: %d, email: %s) was successfully deleted.', $user->getUsername(), $userId, $user->getEmail()));
+        (new SymfonyStyle($input, $output))
+            ->success(sprintf('User "%s" (ID: %d, email: %s) was successfully deleted.', $user->getUsername(), $userId, $user->getEmail()));
     }
 
     /**

--- a/src/AppBundle/Command/DeleteUserCommand.php
+++ b/src/AppBundle/Command/DeleteUserCommand.php
@@ -17,7 +17,6 @@ use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
@@ -82,7 +81,6 @@ HELP
         // See: http://symfony.com/doc/current/console/style.html
         $io = new SymfonyStyle($input, $output);
 
-
         $io->title('Delete User Command Interactive Wizard');
 
         $io->text([
@@ -95,11 +93,8 @@ HELP
             '',
         ]);
 
-        $question = new Question(' > <info>Username</info>: ');
-        $question->setValidator([$this, 'usernameValidator']);
-        $question->setMaxAttempts(self::MAX_ATTEMPTS);
+        $username = $io->ask('Username', null, [$this, 'usernameValidator']);
 
-        $username = $io->askQuestion($question);
         $input->setArgument('username', $username);
     }
 

--- a/src/AppBundle/Command/ListUsersCommand.php
+++ b/src/AppBundle/Command/ListUsersCommand.php
@@ -111,7 +111,8 @@ HELP
         $table
             ->setHeaders(['ID', 'Full Name', 'Username', 'Email', 'Roles'])
             ->setRows($usersAsPlainArrays)
-        ;
+            ->setStyle(clone Table::getStyleDefinition('symfony-style-guide'))
+       ;
         $table->render();
 
         // instead of displaying the table of users, store it in a variable


### PR DESCRIPTION
Ref.: #472

This will  use the `SymfonyStyle` style for console commands.

Unfortunately the advanced features used are no supported so we can't really live without the "low level" helpers...
* `Question` max attempts
* `Table` using `BufferedOutput` to "capture" the table

I have removed the "max attempts" feature from the `delete-user` command and was also tempted to remove this behavior in the `add-user` command on the fields that doesn't do much validation (user name and full name) - WDYT?