### PR TITLE
Replaced kernel.root_dir by kernel.project_dir

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -33,7 +33,7 @@ framework:
     translator:      { fallback: '%locale%' }
     secret:          '%env(SYMFONY_SECRET)%'
     router:
-        resource: '%kernel.root_dir%/config/routing.yml'
+        resource: '%kernel.project_dir%/app/config/routing.yml'
         strict_requirements: ~
     form:            ~
     csrf_protection: ~

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -3,7 +3,7 @@ imports:
 
 framework:
     router:
-        resource: "%kernel.root_dir%/config/routing_dev.yml"
+        resource: "%kernel.project_dir%/app/config/routing_dev.yml"
         strict_requirements: true
     profiler: { only_exceptions: false }
 

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -21,7 +21,7 @@ web_profiler:
 # In this case we just need to define a different path for the application database.
 doctrine:
     dbal:
-        path: "%kernel.root_dir%/../var/data/blog_test.sqlite"
+        path: "%kernel.project_dir%/var/data/blog_test.sqlite"
 
 # this configuration simplifies testing URLs protected by the security mechanism
 # See https://symfony.com/doc/current/cookbook/testing/http_authentication.html

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -17,7 +17,7 @@ parameters:
     # this demo application uses an embedded SQLite database to simplify setup.
     # in a real Symfony application you probably will use a MySQL or PostgreSQL database
     # the path must be relative or else it will not work on Windows
-    env(DATABASE_URL): 'sqlite:///%kernel.root_dir%/../var/data/blog.sqlite'
+    env(DATABASE_URL): 'sqlite:///%kernel.project_dir%/var/data/blog.sqlite'
 
     # Uncomment this line to use a MySQL database instead of SQLite (and remove
     # the "doctrine" section from config_dev.yml regarding SQLite):

--- a/src/CodeExplorerBundle/Resources/config/services.yml
+++ b/src/CodeExplorerBundle/Resources/config/services.yml
@@ -2,7 +2,6 @@ services:
     code_explorer.twig.source_code_extension:
         public:    false
         class:     CodeExplorerBundle\Twig\SourceCodeExtension
-        arguments: ['%kernel.root_dir%']
         tags:
             - { name: twig.extension }
 

--- a/src/CodeExplorerBundle/Twig/SourceCodeExtension.php
+++ b/src/CodeExplorerBundle/Twig/SourceCodeExtension.php
@@ -23,12 +23,6 @@ namespace CodeExplorerBundle\Twig;
 class SourceCodeExtension extends \Twig_Extension
 {
     private $controller;
-    private $kernelRootDir;
-
-    public function __construct($kernelRootDir)
-    {
-        $this->kernelRootDir = $kernelRootDir;
-    }
 
     public function setController($controller)
     {


### PR DESCRIPTION
As explained in https://symfony.com/blog/new-in-symfony-3-3-a-simpler-way-to-get-the-project-root-directory