### PR TITLE
Removed the deprecated getName() method in Twig extensions

### DIFF
--- a/src/AppBundle/Twig/AppExtension.php
+++ b/src/AppBundle/Twig/AppExtension.php
@@ -95,14 +95,4 @@ class AppExtension extends \Twig_Extension
 
         return $locales;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        // the name of the Twig extension must be unique in the application. Consider
-        // using 'app.extension' if you only have one Twig extension in your application.
-        return 'app.extension';
-    }
 }

--- a/src/CodeExplorerBundle/Twig/SourceCodeExtension.php
+++ b/src/CodeExplorerBundle/Twig/SourceCodeExtension.php
@@ -138,10 +138,4 @@ class SourceCodeExtension extends \Twig_Extension
 
         return $formattedCode;
     }
-
-    // the name of the Twig extension must be unique in the application
-    public function getName()
-    {
-        return 'code_explorer_source_code';
-    }
 }


### PR DESCRIPTION
```
        /**
         * Returns the name of the extension.
         *
         * @return string The extension name
         *
         * @deprecated since 1.26 (to be removed in 2.0), not used anymore internally
         */
        function getName();
```