### PR TITLE
Use DSN-like strings to define credentials

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -62,16 +62,6 @@ doctrine:
     dbal:
         # if you don't want to use SQLite, change the URL in parameters.yml or set the DATABASE_URL environment variable
         url: '%env(DATABASE_URL)%'
-
-        # instead of using a URL, you may also uncomment the following lines to configure your database
-        # driver:   pdo_mysql
-        # host:     '%database_host%'
-        # port:     '%database_port%'
-        # dbname:   '%database_name%'
-        # user:     '%database_user%'
-        # password: '%database_password%'
-        # charset:  UTF8
-
     orm:
         auto_generate_proxy_classes: '%kernel.debug%'
         auto_mapping: true
@@ -83,8 +73,5 @@ doctrine:
 # stores options that change from one server to another
 #
 swiftmailer:
-    transport: '%mailer_transport%'
-    host:      '%mailer_host%'
-    username:  '%mailer_user%'
-    password:  '%mailer_password%'
-    spool:     { type: memory }
+    url : '%env(MAILER_URL)%'
+    spool: { type: memory }

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -15,14 +15,6 @@ web_profiler:
 # swiftmailer:
 #     disable_delivery: true
 
-# It's recommended to use a separate database for tests. This allows to have a
-# fixed and known set of data fixtures, it simplifies the code of tests and it
-# makes them more robust.
-# In this case we just need to define a different path for the application database.
-doctrine:
-    dbal:
-        url: 'sqlite://%kernel.project_dir%/var/data/blog_test.sqlite'
-
 # this configuration simplifies testing URLs protected by the security mechanism
 # See https://symfony.com/doc/current/cookbook/testing/http_authentication.html
 security:

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -21,7 +21,7 @@ web_profiler:
 # In this case we just need to define a different path for the application database.
 doctrine:
     dbal:
-        path: "%kernel.project_dir%/var/data/blog_test.sqlite"
+        url: 'sqlite://%kernel.project_dir%/var/data/blog_test.sqlite'
 
 # this configuration simplifies testing URLs protected by the security mechanism
 # See https://symfony.com/doc/current/cookbook/testing/http_authentication.html

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -33,7 +33,4 @@ parameters:
 
     # If you don't use a real mail server, you can send emails via your Gmail account.
     # see https://symfony.com/doc/current/cookbook/email/gmail.html
-    mailer_transport:  smtp
-    mailer_host:       127.0.0.1
-    mailer_user:       ~
-    mailer_password:   ~
+    env(MAILER_URL): 'smtp://localhost:25?encryption=&auth_mode='

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -17,7 +17,7 @@ parameters:
     # this demo application uses an embedded SQLite database to simplify setup.
     # in a real Symfony application you probably will use a MySQL or PostgreSQL database
     # the path must be relative or else it will not work on Windows
-    env(DATABASE_URL): 'sqlite://%kernel.project_dir%/var/data/blog.sqlite'
+    env(DATABASE_URL): 'sqlite:///%kernel.project_dir%/var/data/blog.sqlite'
 
     # Uncomment this line to use a MySQL database instead of SQLite (and remove
     # the "doctrine" section from config_dev.yml regarding SQLite):

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -17,7 +17,7 @@ parameters:
     # this demo application uses an embedded SQLite database to simplify setup.
     # in a real Symfony application you probably will use a MySQL or PostgreSQL database
     # the path must be relative or else it will not work on Windows
-    env(DATABASE_URL): 'sqlite:///%kernel.project_dir%/var/data/blog.sqlite'
+    env(DATABASE_URL): 'sqlite://%kernel.project_dir%/var/data/blog.sqlite'
 
     # Uncomment this line to use a MySQL database instead of SQLite (and remove
     # the "doctrine" section from config_dev.yml regarding SQLite):

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,7 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <server name="KERNEL_DIR" value="app/" />
-        <env name="DATABASE_URL" value="sqlite://%kernel.project_dir%/var/data/blog_test.sqlite"/>
+        <env name="DATABASE_URL" value="sqlite:///%kernel.project_dir%/var/data/blog_test.sqlite"/>
     </php>
 
     <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,7 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <server name="KERNEL_DIR" value="app/" />
+        <env name="DATABASE_URL" value="sqlite://%kernel.project_dir%/var/data/blog_test.sqlite"/>
     </php>
 
     <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,7 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <server name="KERNEL_DIR" value="app/" />
-        <env name="DATABASE_URL" value="sqlite:///%kernel.project_dir%/var/data/blog_test.sqlite"/>
+        <env name="DATABASE_URL" value="sqlite:///var/data/blog_test.sqlite"/>
     </php>
 
     <testsuites>


### PR DESCRIPTION
This is the new best practice for modern Symfony apps. See https://github.com/symfony/recipes/blob/master/symfony/swiftmailer-bundle/2.5/etc/packages/swiftmailer.yaml