### PR TITLE
Fix console error listener when there is no command yet

### DIFF
--- a/src/AppBundle/EventListener/CheckRequirementsSubscriber.php
+++ b/src/AppBundle/EventListener/CheckRequirementsSubscriber.php
@@ -67,7 +67,7 @@ class CheckRequirementsSubscriber implements EventSubscriberInterface
     {
         $commandNames = ['doctrine:fixtures:load', 'doctrine:database:create', 'doctrine:schema:create', 'doctrine:database:drop'];
 
-        if (in_array($event->getCommand()->getName(), $commandNames, true)) {
+        if ($event->getCommand() && in_array($event->getCommand()->getName(), $commandNames, true)) {
             if ($this->isSQLitePlatform() && !extension_loaded('sqlite3')) {
                 $io = new SymfonyStyle($event->getInput(), $event->getOutput());
                 $io->error('This command requires to have the "sqlite3" PHP extension enabled because, by default, the Symfony Demo application uses SQLite to store its information.');


### PR DESCRIPTION
Fixes an issue when there isn't any command yet and an error was triggered. For instance, when trying to use a non-existing command.

> PHP Fatal error:  Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Call to a member function getName() on null in src/AppBundle/EventListener/CheckRequirementsSubscriber.php:70