### PR TITLE
Use 3.3 DI features in CodeExplorerBundle

### DIFF
--- a/src/CodeExplorerBundle/EventListener/ControllerListener.php
+++ b/src/CodeExplorerBundle/EventListener/ControllerListener.php
@@ -12,22 +12,18 @@
 namespace CodeExplorerBundle\EventListener;
 
 use CodeExplorerBundle\Twig\SourceCodeExtension;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
  * Defines the method that 'listens' to the 'kernel.controller' event, which is
  * triggered whenever a controller is executed in the application.
  *
- * See https://symfony.com/doc/current/book/internals.html#kernel-controller-event
- *
- * Tip: listeners are common in Symfony applications, but this particular listener
- * is too advanced and too specific for the demo application needs. For more common
- * examples see https://symfony.com/doc/current/cookbook/service_container/event_listener.html
- *
  * @author Ryan Weaver <weaverryan@gmail.com>
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-class ControllerListener
+class ControllerListener implements EventSubscriberInterface
 {
     private $twigExtension;
 
@@ -44,5 +40,15 @@ class ControllerListener
         if ($event->isMasterRequest()) {
             $this->twigExtension->setController($event->getController());
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::CONTROLLER => 'registerCurrentController',
+        ];
     }
 }

--- a/src/CodeExplorerBundle/Resources/config/services.yml
+++ b/src/CodeExplorerBundle/Resources/config/services.yml
@@ -1,12 +1,6 @@
 services:
-    code_explorer.twig.source_code_extension:
-        public:    false
-        class:     CodeExplorerBundle\Twig\SourceCodeExtension
-        tags:
-            - { name: twig.extension }
+    _defaults: { public: false, autoconfigure: true }
 
-    code_explorer.controller_listener:
-        class:     CodeExplorerBundle\EventListener\ControllerListener
-        arguments: ['@code_explorer.twig.source_code_extension']
-        tags:
-            - { name: kernel.event_listener, event: kernel.controller, method: registerCurrentController }
+    CodeExplorerBundle\Twig\SourceCodeExtension: ~
+
+    CodeExplorerBundle\EventListener\ControllerListener: ['@CodeExplorerBundle\Twig\SourceCodeExtension']


### PR DESCRIPTION
Since 3.3, [listeners do not have to be public anymore](https://github.com/symfony/symfony/pull/20953/files#diff-8604f72b4ae78c6c364c1af8c1dee17cL63).
I also believe declaring services private by default by adding `_defaults: { public: false }` on top will become a best practice, so I think we should use it in the CodeExplorerBundle.

Actually, we could also use classnamed services, autoconfigure and autowiring, but at least for the last one, I think we should keep a place in this application where services are declared entirely manually (autoconfigure is debatable this way too, that's true).

WDYT?