### PR TITLE
Update logs configuration

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -48,6 +48,8 @@ framework:
     fragments:       ~
     http_method_override: true
     assets: ~
+    php_errors:
+        log: true
 
 # Twig Configuration (used for rendering application templates)
 twig:

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -14,12 +14,20 @@ web_profiler:
 monolog:
     handlers:
         main:
-            type:   stream
-            path:   "%env(SYMFONY_LOG)%"
-            level:  info
+            type: stream
+            path: '%env(LOG_URL)%'
+            level: debug
+            channels: ['!event']
         console:
-            type:   console
-            bubble: false
+            type: console
+            process_psr_3_messages: false
+            channels: ['!event', '!doctrine', '!console']
+        # To follow logs in real time, execute the following command:
+        # `bin/console server:log -vv`
+        server_log:
+            type: server_log
+            process_psr_3_messages: false
+            host: 127.0.0.1:9911
         # uncomment to get logging in your browser
         # you may have to allow bigger header sizes in your Web server configuration
         #firephp:

--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -19,7 +19,7 @@ monolog:
             handler:      nested
         nested:
             type:  stream
-            path:  "%env(SYMFONY_LOG)%"
+            path:  '%env(LOG_URL)%'
             level: debug
         console:
             type:  console

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -12,7 +12,7 @@ parameters:
     env(SYMFONY_SECRET): 'secret_value_for_symfony_demo_application'
 
     # Destination for log files; can also be "php://stderr" etc
-    env(SYMFONY_LOG): '%kernel.logs_dir%/%kernel.environment%.log'
+    env(LOG_URL): '%kernel.logs_dir%/%kernel.environment%.log'
 
     # this demo application uses an embedded SQLite database to simplify setup.
     # in a real Symfony application you probably will use a MySQL or PostgreSQL database


### PR DESCRIPTION
to match the standard edition configuration, which is way more convenient.
In dev, it'll now log every debug information but events, console errors are now logged natively and we don't need them to be output on stderr (we already have the stacktrace when running the console), and the `server:log` command allows to see logs in real-time.