### PR TITLE
Alias the slugger to fix fixtures loading

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -44,3 +44,9 @@ services:
 
     # needed for the localizeddate Twig filter
     Twig\Extensions\IntlExtension: ~
+
+    # the slugger service needs a public alias for getting it from
+    # the container when loading doctrine fixtures
+    slugger:
+        alias: AppBundle\Utils\Slugger
+        public: true


### PR DESCRIPTION
Fixes current exception:

```php
[Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]         
  You have requested a non-existent service "slugger". Did you mean this: "logger"?  
```

`ContainerAwareInterface` still is the way to access services inside fixture loaders. Maybe something could be done on the doctrine-fixtures-bundle side, but for now we need to have a public alias for this service.
We could also exclude the `DataFixtures\ORM` folder from PSR-4 loading, but it's probably not worth it and may "overwhelm" a little newcomers:

```diff
-        exclude: '../../src/AppBundle/{Controller,Entity,Repository}'
+        exclude: '../../src/AppBundle/{Controller,Entity,Repository,DataFixtures/ORM}'
```