### PR TITLE
[Webpack/Moment] Include all moment locales

### DIFF
--- a/src/AppBundle/Form/Type/DateTimePickerType.php
+++ b/src/AppBundle/Form/Type/DateTimePickerType.php
@@ -41,7 +41,7 @@ class DateTimePickerType extends AbstractType
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $view->vars['attr']['data-date-format'] = $this->formatConverter->convert($options['format']);
-        $view->vars['attr']['data-date-locale'] = \Locale::getDefault();
+        $view->vars['attr']['data-date-locale'] = mb_strtolower(strtr(\Locale::getDefault(), '_', '-'));
     }
 
     /**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,11 +21,4 @@ Encore
     .addStyleEntry('css/admin', ['./app/Resources/assets/scss/admin.scss'])
 ;
 
-var config = Encore.getWebpackConfig();
-
-config.plugins.push(new webpack.ContextReplacementPlugin(
-    /moment[\/\\]locale$/,
-    /en|fr|de|es|cs|nl|ru|uk|ro|pt-br|pl|it|ja|id|ca|sl|hr|zh-cn/
-));
-
-module.exports = config;
+module.exports = Encore.getWebpackConfig();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,9 @@ Encore
 
 var config = Encore.getWebpackConfig();
 
-config.plugins.push(new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/));
+config.plugins.push(new webpack.ContextReplacementPlugin(
+    /moment[\/\\]locale$/,
+    /en|fr|de|es|cs|nl|ru|uk|ro|pt-br|pl|it|ja|id|ca|sl|hr|zh-cn/
+));
 
 module.exports = config;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,4 @@
 var Encore = require('@symfony/webpack-encore');
-var webpack = require('webpack');
 
 Encore
     .setOutputPath('web/build/')


### PR DESCRIPTION
This resolves #591 if someone else can confirm the same error.

The `admin.js` file size in production increases to `227k` (from `178k`)

The locale list comes from `config.yml`:
```yaml
parameters:
    # This parameter defines the codes of the locales (languages) enabled in the application
    app_locales: en|fr|de|es|cs|nl|ru|uk|ro|pt_BR|pl|it|ja|id|ca|sl|hr|zh_CN
```