### PR TITLE
services: added name to the quote

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -42,7 +42,7 @@ services:
         $locales: '%app_locales%'
         $defaultLocale: '%locale%'
 
-    # needed for the localizeddate Twig filter
+    # needed for the 'localizeddate' Twig filter
     Twig\Extensions\IntlExtension: ~
 
     # the slugger service needs a public alias for getting it from


### PR DESCRIPTION
So it's clear it's name of the filter and not English.

I was about to send PR with space "localized date", but then I've read the "filter". So I hope this is the correct option :)