### PR TITLE
Removed PHPUnit as a dependency and rely on PHPUnit Bridge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - composer install
 
 script:
-  - ./vendor/bin/phpunit
+  - ./vendor/bin/simple-phpunit
   # this checks that the source code follows the Symfony Code Syntax rules
   - ./vendor/bin/php-cs-fixer fix --diff --dry-run -v
   # this checks that the YAML config files contain no syntax errors

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,6 @@
     "require-dev": {
         "dama/doctrine-test-bundle"            : "^1.0",
         "friendsofphp/php-cs-fixer"            : "^2.0",
-        "phpunit/phpunit"                      : "^4.8 || ^5.0",
         "sensio/generator-bundle"              : "^3.0",
         "symfony/phpunit-bridge"               : "^3.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "746cbb988fffb23fbb88c44470958d5d",
+    "content-hash": "fa64b0dc5f2f343c89c2e1a4573711cd",
     "packages": [
         {
             "name": "composer/ca-bundle",


### PR DESCRIPTION
We discussed about this in the past. I think it's better this way because using PHPUnit Bridge instead of PHPUnit is the recommended way (as explained in the Symfony Docs).