### PR TITLE
Update php version requirement in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ to develop Symfony applications following the recommended best practices.
 Requirements
 ------------
 
-  * PHP 5.5.9 or higher;
+  * PHP 7.1.3 or higher;
   * PDO-SQLite PHP extension enabled;
   * and the [usual Symfony application requirements](https://symfony.com/doc/current/reference/requirements.html).
 


### PR DESCRIPTION
Hi

Seems that symfony-demo in no longer available for php 5.5.9.
Composer.json define the minimum requirement to 7.1.3.

Readme update