### PR TITLE
Remove forced configuration for tests environment

### DIFF
--- a/config/packages/test/doctrine.yaml
+++ b/config/packages/test/doctrine.yaml
@@ -1,9 +1,0 @@
-parameters:
-    # needed to avoid this fatal error:
-    # Symfony\Component\DependencyInjection\Exception\EnvParameterException:
-    # Environment variables "DATABASE_URL" are never used. Please, check your container's configuration.
-    ignore-this-parameter: '%env(DATABASE_URL)%'
-
-doctrine:
-    dbal:
-        url: 'sqlite:///var/data/blog_test.sqlite'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,7 @@
                Environment variable not found: "APP_SECRET".
         -->
         <env name="APP_SECRET" value="5a79a1c866efef9ca1800f971d689f3e"/>
+        <env name="DATABASE_URL" value="sqlite:///var/data/blog_test.sqlite"/>
     </php>
 
     <testsuites>


### PR DESCRIPTION
We can configure the test database file in `phpunit.xml.dist` and keep it simple.