### PR TITLE
Workaround to use DATABASE_URL with %kernel.project_dir% parameter

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -12,7 +12,7 @@ APP_SECRET=67d829bf61dc5f87a73fd814e2c9f629
 # Format described at http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
 # For a sqlite database, use: "sqlite:///%kernel.project_dir%/var/data.db"
 # Set "serverVersion" to your server version to avoid edge-case exceptions and extra database calls
-DATABASE_URL=sqlite:///var/data/blog.sqlite
+DATABASE_URL=sqlite:///%kernel.project_dir%/var/data/blog.sqlite
 ###< doctrine/doctrine-bundle ###
 
 ###> symfony/swiftmailer-bundle ###

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -14,6 +14,7 @@ namespace App;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 use Symfony\Component\Routing\RouteCollectionBuilder;
 
@@ -25,6 +26,24 @@ final class Kernel extends BaseKernel
     use MicroKernelTrait;
 
     private const CONFIG_EXTS = '.{php,xml,yaml,yml}';
+
+    public function __construct($environment, $debug)
+    {
+        /*
+         * Workaround to avoid: An exception occurred in driver: SQLSTATE[HY000] [14] unable to open database file
+         * As environment variables is not supported yet to be used with configuration parameters.
+         *
+         * @TODO remove in 3.4
+         */
+
+        if (isset($_ENV['DATABASE_URL']) && false !== mb_strpos($_ENV['DATABASE_URL'], '%kernel.project_dir%')) {
+            (new Dotenv())->populate([
+                'DATABASE_URL' => str_replace('%kernel.project_dir%', $this->getProjectDir(), $_ENV['DATABASE_URL']),
+            ]);
+        }
+
+        parent::__construct($environment, $debug);
+    }
 
     public function getCacheDir(): string
     {


### PR DESCRIPTION
Setting `DATABASE_URL=sqlite:///var/data/blog.sqlite` as default, causes this known error through `index.php`:
```
An exception occurred in driver: SQLSTATE[HY000] [14] unable to open database file
```
So the right relative path in this case should be `sqlite:///../var/data/blog.sqlite` BUT then it wouldn't work for `bin/console` entries. Then, relative paths shouldn't be the right way but absolute paths.

The right thing is that soon (in 3.4 & 4.0) we can use environment variables with configuration parameters https://github.com/symfony/symfony/pull/23901, so the final configuration would be the one proposed. For now a workaround to make both scenarios work `index.php` and `bin/console`.