### PR TITLE
Simplify PHPUnit config

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,14 +10,6 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <server name="KERNEL_CLASS" value="App\Kernel" />
-        <!--
-            TODO: if you don't define APP_SECRET env var, you see this error:
-            1) App\Tests\Controller\Admin\BlogControllerTest::testAccessDeniedForRegularUsers
-               with data set #0 ('GET', '/en/admin/post/')
-               Symfony\Component\DependencyInjection\Exception\EnvNotFoundException:
-               Environment variable not found: "APP_SECRET".
-        -->
-        <env name="APP_SECRET" value="5a79a1c866efef9ca1800f971d689f3e"/>
         <env name="DATABASE_URL" value="sqlite:///var/data/blog_test.sqlite"/>
     </php>
 


### PR DESCRIPTION
A continuation of #627 ... if I remove this setting, I see this error in every test:

```
20) App\Tests\Controller\DefaultControllerTest::testSecureUrls with data set #3 ('/en/admin/post/1/edit')
Symfony\Component\DependencyInjection\Exception\EnvNotFoundException:
Environment variable not found: "APP_SECRET".

symfony-demo/vendor/symfony/dependency-injection/Container.php:451
symfony-demo/var/cache/test/srcTestDebugProjectContainer.php:3081
symfony-demo/vendor/symfony/dependency-injection/Container.php:335
symfony-demo/var/cache/test/srcTestDebugProjectContainer.php:1670
symfony-demo/vendor/symfony/dependency-injection/Container.php:335
symfony-demo/var/cache/test/srcTestDebugProjectContainer.php:809
symfony-demo/vendor/symfony/event-dispatcher/EventDispatcher.php:145
symfony-demo/vendor/symfony/event-dispatcher/ContainerAwareEventDispatcher.php:110
symfony-demo/vendor/symfony/event-dispatcher/Debug/TraceableEventDispatcher.php:256
symfony-demo/vendor/symfony/event-dispatcher/Debug/TraceableEventDispatcher.php:141
symfony-demo/vendor/symfony/http-kernel/HttpKernel.php:129
symfony-demo/vendor/symfony/http-kernel/HttpKernel.php:68
symfony-demo/vendor/symfony/http-kernel/EventListener/ExceptionListener.php:50
symfony-demo/vendor/symfony/event-dispatcher/Debug/WrappedListener.php:104
symfony-demo/vendor/symfony/event-dispatcher/EventDispatcher.php:212
symfony-demo/vendor/symfony/event-dispatcher/EventDispatcher.php:44
symfony-demo/vendor/symfony/event-dispatcher/Debug/TraceableEventDispatcher.php:146
symfony-demo/vendor/symfony/http-kernel/HttpKernel.php:230
symfony-demo/vendor/symfony/http-kernel/HttpKernel.php:79
symfony-demo/vendor/symfony/http-kernel/Kernel.php:171
symfony-demo/vendor/symfony/http-kernel/Client.php:61
symfony-demo/vendor/symfony/framework-bundle/Client.php:131
symfony-demo/vendor/symfony/browser-kit/Client.php:315
symfony-demo/tests/App/Controller/DefaultControllerTest.php:76
symfony-demo/vendor/symfony/phpunit-bridge/bin/.phpunit/phpunit-5.7/phpunit:5

Caused by
Symfony\Component\DependencyInjection\Exception\EnvNotFoundException:
Environment variable not found: "APP_SECRET".
```

Has anyone a solution for this problem? Thanks!