### PR TITLE
Change tests namespaces: 'App\Tests' -> 'Tests\App'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "App\\Tests\\": "tests/"
+            "Tests\\App\\": "tests/"
         }
     },
     "scripts": {

--- a/tests/Command/AddUserCommandTest.php
+++ b/tests/Command/AddUserCommandTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace App\Tests\Command;
+namespace Tests\App\Command;
 
 use App\Command\AddUserCommand;
 use App\Entity\User;

--- a/tests/Controller/Admin/BlogControllerTest.php
+++ b/tests/Controller/Admin/BlogControllerTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace App\Tests\Controller\Admin;
+namespace Tests\App\Controller\Admin;
 
 use App\DataFixtures\FixturesTrait;
 use App\Entity\Post;

--- a/tests/Controller/BlogControllerTest.php
+++ b/tests/Controller/BlogControllerTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace App\Tests\Controller;
+namespace Tests\App\Controller;
 
 use App\Entity\Post;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;

--- a/tests/Controller/DefaultControllerTest.php
+++ b/tests/Controller/DefaultControllerTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace App\Tests\Controller;
+namespace Tests\App\Controller;
 
 use App\Entity\Post;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;

--- a/tests/Form/DataTransformer/TagArrayToStringTransformerTest.php
+++ b/tests/Form/DataTransformer/TagArrayToStringTransformerTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace App\Tests\Form\DataTransformer;
+namespace Tests\App\Form\DataTransformer;
 
 use App\Entity\Tag;
 use App\Form\DataTransformer\TagArrayToStringTransformer;

--- a/tests/Utils/SluggerTest.php
+++ b/tests/Utils/SluggerTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace App\Tests\Utils;
+namespace Tests\App\Utils;
 
 use App\Utils\Slugger;
 

--- a/tests/Utils/ValidatorTest.php
+++ b/tests/Utils/ValidatorTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace App\Tests\Utils;
+namespace Tests\App\Utils;
 
 use App\Utils\Validator;
 


### PR DESCRIPTION
I'm pretty sure this way is more intuitive, and, actually, this way is used in Symfony Best Practices: http://symfony.com/doc/current/best_practices/tests.html