### PR TITLE
Remove useless constants in commands

### DIFF
--- a/src/Command/AddUserCommand.php
+++ b/src/Command/AddUserCommand.php
@@ -44,8 +44,6 @@ use Symfony\Component\Stopwatch\Stopwatch;
  */
 class AddUserCommand extends Command
 {
-    const MAX_ATTEMPTS = 5;
-
     private $io;
     private $entityManager;
     private $passwordEncoder;

--- a/src/Command/DeleteUserCommand.php
+++ b/src/Command/DeleteUserCommand.php
@@ -39,8 +39,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  */
 class DeleteUserCommand extends Command
 {
-    const MAX_ATTEMPTS = 5;
-
     private $io;
     private $entityManager;
     private $validator;


### PR DESCRIPTION
After https://github.com/symfony/symfony-demo/commit/5180bdcce3bac08e59ba9b5d34fbd7c2b007f7e3