### PR TITLE
Fix the CI on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,4 +48,4 @@ install:
 
 test_script:
     - cd c:\projects\symfony-demo
-    - php vendor/bin/simple-phpunit
+    - vendor/bin/simple-phpunit


### PR DESCRIPTION
On windows, composer does not use a symlink when installing binaries but creates a proxy script instead. This proxy is not a PHP script, so running it through PHP does not work.
The goal of composer is to allow running the script in a way similar to the Linux usage relying on shebangs.

So tests were not running on AppVeyor: https://ci.appveyor.com/project/fabpot/symfony-demo/build/1.0.1088#L140