### PR TITLE
Cache the phpunit install between builds on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ sudo: false
 cache:
   directories:
     - $HOME/.composer/cache/files
+    - $HOME/symfony-bridge/.phpunit
+
+env:
+  global:
+    - SYMFONY_PHPUNIT_DIR="$HOME/symfony-bridge/.phpunit"
 
 matrix:
   fast_finish: true
@@ -16,6 +21,7 @@ before_install:
 
 install:
   - composer install
+  - ./vendor/bin/simple-phpunit install
 
 script:
   - ./vendor/bin/simple-phpunit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,12 +4,14 @@ clone_folder: c:\projects\symfony-demo
 
 cache:
     - '%LOCALAPPDATA%\Composer\files'
+    - '%LOCALAPPDATA%\SymfonyBridge\phpunit'
     - c:\projects\symfony-demo\composer.phar
 
 init:
     - SET PATH=c:\php;%PATH%
     - SET COMPOSER_NO_INTERACTION=1
     - SET SYMFONY_DEPRECATIONS_HELPER=strict
+    - SET SYMFONY_PHPUNIT_DIR=%LOCALAPPDATA%\SymfonyBridge\phpunit
     - SET ANSICON=121x90 (121x90)
     - REG ADD "HKEY_CURRENT_USER\Software\Microsoft\Command Processor" /v DelayedExpansion /t REG_DWORD /d 1 /f
 
@@ -45,6 +47,7 @@ install:
     - IF %APPVEYOR_REPO_BRANCH%==master (SET COMPOSER_ROOT_VERSION=dev-master) ELSE (SET COMPOSER_ROOT_VERSION=%APPVEYOR_REPO_BRANCH%.x-dev)
     - php composer.phar update --no-progress --ansi
     - SET COMPOSER_ROOT_VERSION=
+    - vendor\bin\simple-phpunit install
 
 test_script:
     - cd c:\projects\symfony-demo


### PR DESCRIPTION
This leverages the CI caches to avoid redownloading PHPUnit on each build with the bridge.
This implies changing the folder in which it gets downloaded to allow caching without side-effects on the composer install (by default, the install happens in `vendor/symfony/phpunit-bridge/bin/.phpunit` but composer cleans existing folders when installing packages)

This also separates the PHPUnit install from the run instead of relying on the lazy-install, to make the output more understandable (especially on Travis where the install part will get collapsed).
Seeing a composer output when running tests can be confusing.