### PR TITLE
Update Entities to use Doctrine 2.6 types

### DIFF
--- a/src/DataFixtures/ORM/PostFixtures.php
+++ b/src/DataFixtures/ORM/PostFixtures.php
@@ -48,7 +48,7 @@ class PostFixtures extends AbstractFixture implements DependentFixtureInterface
             $post->setSummary($this->getRandomPostSummary());
             $post->setSlug(Slugger::slugify($post->getTitle()));
             $post->setContent($this->getPostContent());
-            $post->setPublishedAt(new \DateTime('now - '.$i.'days'));
+            $post->setPublishedAt(new \DateTimeImmutable('now - '.$i.'days'));
 
             // Ensure that the first post is written by Jane Doe to simplify tests
             // "References" are the way to share objects between fixtures defined
@@ -65,7 +65,7 @@ class PostFixtures extends AbstractFixture implements DependentFixtureInterface
                 $comment = new Comment();
 
                 $comment->setAuthor($this->getReference('john-user'));
-                $comment->setPublishedAt(new \DateTime('now + '.($i + $j).'seconds'));
+                $comment->setPublishedAt(new \DateTimeImmutable('now + '.($i + $j).'seconds'));
                 $comment->setContent($this->getRandomCommentContent());
 
                 $post->addComment($comment);

--- a/src/Entity/Comment.php
+++ b/src/Entity/Comment.php
@@ -61,9 +61,9 @@ class Comment
     private $content;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeImmutable
      *
-     * @ORM\Column(type="datetime")
+     * @ORM\Column(type="datetime_immutable")
      * @Assert\DateTime
      */
     private $publishedAt;
@@ -78,7 +78,7 @@ class Comment
 
     public function __construct()
     {
-        $this->publishedAt = new \DateTime();
+        $this->publishedAt = new \DateTimeImmutable();
     }
 
     /**
@@ -106,12 +106,12 @@ class Comment
         $this->content = $content;
     }
 
-    public function getPublishedAt(): \DateTime
+    public function getPublishedAt(): \DateTimeInterface
     {
         return $this->publishedAt;
     }
 
-    public function setPublishedAt(\DateTime $publishedAt): void
+    public function setPublishedAt(\DateTimeInterface $publishedAt): void
     {
         $this->publishedAt = $publishedAt;
     }

--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -83,9 +83,9 @@ class Post
     private $content;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeImmutable
      *
-     * @ORM\Column(type="datetime")
+     * @ORM\Column(type="datetime_immutable")
      * @Assert\DateTime
      */
     private $publishedAt;
@@ -122,7 +122,7 @@ class Post
 
     public function __construct()
     {
-        $this->publishedAt = new \DateTime();
+        $this->publishedAt = new \DateTimeImmutable();
         $this->comments = new ArrayCollection();
         $this->tags = new ArrayCollection();
     }
@@ -162,12 +162,12 @@ class Post
         $this->content = $content;
     }
 
-    public function getPublishedAt(): \DateTime
+    public function getPublishedAt(): \DateTimeInterface
     {
         return $this->publishedAt;
     }
 
-    public function setPublishedAt(\DateTime $publishedAt): void
+    public function setPublishedAt(\DateTimeInterface $publishedAt): void
     {
         $this->publishedAt = $publishedAt;
     }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -69,7 +69,7 @@ class User implements UserInterface, \Serializable
     /**
      * @var array
      *
-     * @ORM\Column(type="json_array")
+     * @ORM\Column(type="json")
      */
     private $roles = [];
 

--- a/src/Repository/PostRepository.php
+++ b/src/Repository/PostRepository.php
@@ -40,7 +40,7 @@ class PostRepository extends EntityRepository
                 WHERE p.publishedAt <= :now
                 ORDER BY p.publishedAt DESC
             ')
-            ->setParameter('now', new \DateTime())
+            ->setParameter('now', new \DateTimeImmutable())
         ;
 
         return $this->createPaginator($query, $page);


### PR DESCRIPTION
Tests will fail due to DateTime conversion of `handleRequest()` (src/Controller/Admin/BlogController.php:84)