### PR TITLE
Remove useless exclusion for autowiring

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -24,7 +24,6 @@ services:
     App\:
         resource: '../src/'
         exclude:
-            - '../src/DependencyInjection/'
             - '../src/Entity/'
             - '../src/Kernel.php'
             - '../src/Tests/'


### PR DESCRIPTION
Hello,

Reading the configuration of the project, I was curious to know why this folder was excluded but I couldn't find any trace of it in the current version of the project. So we can safely remove it.