### PR TITLE
Updated Dutch translations

### DIFF
--- a/translations/messages+intl-icu.nl.xlf
+++ b/translations/messages+intl-icu.nl.xlf
@@ -91,6 +91,14 @@
                 <source>title.comment_error</source>
                 <target>Er is een fout opgetreden bij het opslaan van je reactie</target>
             </trans-unit>
+            <trans-unit id="title.edit_user">
+                <source>title.edit_user</source>
+                <target>Wijzig gebruiker</target>
+            </trans-unit>
+            <trans-unit id="title.change_password">
+                <source>title.change_password</source>
+                <target>Wachtwoord wijzigen</target>
+            </trans-unit>
 
             <trans-unit id="action.show">
                 <source>action.show</source>
@@ -169,6 +177,14 @@
                 <source>action.browse_admin</source>
                 <target>Beheerpaneel bekijken</target>
             </trans-unit>
+            <trans-unit id="action.edit_user">
+                <source>action.edit_user</source>
+                <target>Wijzig gebruiker</target>
+            </trans-unit>
+            <trans-unit id="action.change_password">
+                <source>action.change_password</source>
+                <target>Wijzig wachtwoord</target>
+            </trans-unit>
 
             <trans-unit id="label.title">
                 <source>label.title</source>
@@ -190,6 +206,14 @@
                 <source>label.username</source>
                 <target>Gebruikersnaam</target>
             </trans-unit>
+            <trans-unit id="label.fullname">
+                <source>label.fullname</source>
+                <target>Volledige naam</target>
+            </trans-unit>
+            <trans-unit id="label.email">
+                <source>label.email</source>
+                <target>E-mail</target>
+            </trans-unit>
             <trans-unit id="label.password">
                 <source>label.password</source>
                 <target>Wachtwoord</target>
@@ -197,6 +221,18 @@
             <trans-unit id="label.remember_me">
                 <source>label.remember_me</source>
                 <target>Aangemeld blijven</target>
+            </trans-unit>
+            <trans-unit id="label.current_password">
+                <source>label.current_password</source>
+                <target>Huidig wachtwoord</target>
+            </trans-unit>
+            <trans-unit id="label.new_password">
+                <source>label.new_password</source>
+                <target>Nieuw wachtwoord</target>
+            </trans-unit>
+            <trans-unit id="label.new_password_confirm">
+                <source>label.new_password_confirm</source>
+                <target>Herhaal wachtwoord</target>
             </trans-unit>
             <trans-unit id="label.role">
                 <source>label.role</source>
@@ -255,6 +291,10 @@
                 <source>menu.admin</source>
                 <target>Beheerpaneel</target>
             </trans-unit>
+            <trans-unit id="menu.user">
+                <source>menu.user</source>
+                <target>Account</target>
+            </trans-unit>
             <trans-unit id="menu.logout">
                 <source>menu.logout</source>
                 <target>Uitloggen</target>
@@ -309,6 +349,11 @@
                 <target>No results found</target>
             </trans-unit>
 
+            <trans-unit id="user.updated_successfully">
+                <source>user.updated_successfully</source>
+                <target>Gebruiker is succesvol bijgewerkt!</target>
+            </trans-unit>
+
             <trans-unit id="notification.comment_created">
                 <source>notification.comment_created</source>
                 <target>Er is een reactie bij je bericht geplaatst!</target>
@@ -358,6 +403,27 @@
                 <source>help.more_information</source>
                 <target><![CDATA[Voor meer informatie, bekijk de <a href="https://symfony.com/doc">Symfony documentatie</a>.]]></target>
             </trans-unit>
+            <trans-unit id="help.post_summary">
+                <source>help.post_summary</source>
+                <target>Samenvattingen mogen geen Markdown- of HTML-inhoud bevatten; alleen platte tekst.</target>
+            </trans-unit>
+            <trans-unit id="help.post_publication">
+                <source>help.post_publication</source>
+                <target>Stel een datum in de toekomst in om de publicatie van de blogpost te plannen.</target>
+            </trans-unit>
+            <trans-unit id="help.post_content">
+                <source>help.post_content</source>
+                <target>Gebruik Markdown om de inhoud van de blogpost op te maken. HTML is ook toegestaan.</target>
+            </trans-unit>
+            <trans-unit id="help.comment_content">
+                <source>help.comment_content</source>
+                <target>Reacties die niet voldoen aan onze 'Code of Conduct' zullen worden aangepast.</target>
+            </trans-unit>
+
+            <trans-unit id="info.change_password">
+                <source>info.change_password</source>
+                <target>Nadat je je wachtwoord gewijzigd hebt, word je uitgelogd uit de applicatie.</target>
+            </trans-unit>
 
             <trans-unit id="rss.title">
                 <source>rss.title</source>
@@ -375,6 +441,10 @@
             <trans-unit id="paginator.next">
                 <source>paginator.next</source>
                 <target>Volgende</target>
+            </trans-unit>
+            <trans-unit id="paginator.current">
+                <source>paginator.current</source>
+                <target>(huidig)</target>
             </trans-unit>
         </body>
     </file>

--- a/translations/validators+intl-icu.en.xlf
+++ b/translations/validators+intl-icu.en.xlf
@@ -1,43 +1,46 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">
-        <body>
-            <trans-unit id="post.slug_unique">
-                <source>post.slug_unique</source>
-                <target>This title was already used in another blog post, but they must be unique.</target>
-            </trans-unit>
-            <trans-unit id="post.blank_summary">
-                <source>post.blank_summary</source>
-                <target>Give your post a summary!</target>
-            </trans-unit>
-            <trans-unit id="post.blank_content">
-                <source>post.blank_content</source>
-                <target>Your post should have some content!</target>
-            </trans-unit>
-            <trans-unit id="post.too_short_content">
-                <source>post.too_short_content</source>
-                <target>Post content is too short ({ limit } characters minimum)</target>
-            </trans-unit>
-            <trans-unit id="post.too_many_tags">
-                <source>post.too_many_tags</source>
-                <target>Too many tags (add { limit } tags or less)</target>
-            </trans-unit>
-            <trans-unit id="comment.blank">
-                <source>comment.blank</source>
-                <target>Please don't leave your comment blank!</target>
-            </trans-unit>
-            <trans-unit id="comment.too_short">
-                <source>comment.too_short</source>
-                <target>Comment is too short ({ limit } characters minimum)</target>
-            </trans-unit>
-            <trans-unit id="comment.too_long">
-                <source>comment.too_long</source>
-                <target>Comment is too long ({ limit } characters maximum)</target>
-            </trans-unit>
-            <trans-unit id="comment.is_spam">
-                <source>comment.is_spam</source>
-                <target>The content of this comment is considered spam.</target>
-            </trans-unit>
-        </body>
-    </file>
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">
+    <header>
+      <tool tool-id="symfony" tool-name="Symfony"/>
+    </header>
+    <body>
+      <trans-unit id="EEehkgc" resname="post.slug_unique">
+        <source>post.slug_unique</source>
+        <target>This title was already used in another blog post, but they must be unique.</target>
+      </trans-unit>
+      <trans-unit id="TG1D5NO" resname="post.blank_summary">
+        <source>post.blank_summary</source>
+        <target>Give your post a summary!</target>
+      </trans-unit>
+      <trans-unit id="BZOzjk." resname="post.blank_content">
+        <source>post.blank_content</source>
+        <target>Your post should have some content!</target>
+      </trans-unit>
+      <trans-unit id="S6M.YWY" resname="post.too_short_content">
+        <source>post.too_short_content</source>
+        <target>Post content is too short ({ limit } characters minimum)</target>
+      </trans-unit>
+      <trans-unit id="niM7JYj" resname="post.too_many_tags">
+        <source>post.too_many_tags</source>
+        <target>Too many tags (add { limit } tags or less)</target>
+      </trans-unit>
+      <trans-unit id="ARUoKOV" resname="comment.blank">
+        <source>comment.blank</source>
+        <target>Please don't leave your comment blank!</target>
+      </trans-unit>
+      <trans-unit id="J.L_ppQ" resname="comment.too_short">
+        <source>comment.too_short</source>
+        <target>Comment is too short ({ limit } characters minimum)</target>
+      </trans-unit>
+      <trans-unit id=".bkQKXb" resname="comment.too_long">
+        <source>comment.too_long</source>
+        <target>Comment is too long ({ limit } characters maximum)</target>
+      </trans-unit>
+      <trans-unit id="cTT8h4_" resname="comment.is_spam">
+        <source>comment.is_spam</source>
+        <target>The content of this comment is considered spam.</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/translations/validators+intl-icu.nl.xlf
+++ b/translations/validators+intl-icu.nl.xlf
@@ -1,35 +1,46 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" target-language="nl" datatype="plaintext" original="file.ext">
-        <body>
-            <trans-unit id="post.blank_summary">
-                <source>post.blank_summary</source>
-                <target>Geef uw bericht een samenvatting.</target>
-            </trans-unit>
-            <trans-unit id="post.blank_content">
-                <source>post.blank_content</source>
-                <target>Uw bericht heeft nog geen inhoud.</target>
-            </trans-unit>
-            <trans-unit id="post.too_short_content">
-                <source>post.too_short_content</source>
-                <target>Bericht inhoud is te kort (minimaal { limit } karakters)</target>
-            </trans-unit>
-            <trans-unit id="comment.blank">
-                <source>comment.blank</source>
-                <target>Vul alstublieft een reactie in.</target>
-            </trans-unit>
-            <trans-unit id="comment.too_short">
-                <source>comment.too_short</source>
-                <target>Reactie is te kort (minimaal { limit } karakters)</target>
-            </trans-unit>
-            <trans-unit id="comment.too_long">
-                <source>comment.too_long</source>
-                <target>Reactie is te lang (maximaal { limit } karakters)</target>
-            </trans-unit>
-            <trans-unit id="comment.is_spam">
-                <source>comment.is_spam</source>
-                <target>De inhoud van deze reactie wordt als spam gemarkeerd.</target>
-            </trans-unit>
-        </body>
-    </file>
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="nl" datatype="plaintext" original="file.ext">
+    <header>
+      <tool tool-id="symfony" tool-name="Symfony"/>
+    </header>
+    <body>
+      <trans-unit id="TG1D5NO" resname="post.blank_summary">
+        <source>post.blank_summary</source>
+        <target>Geef uw bericht een samenvatting.</target>
+      </trans-unit>
+      <trans-unit id="BZOzjk." resname="post.blank_content">
+        <source>post.blank_content</source>
+        <target>Uw bericht heeft nog geen inhoud.</target>
+      </trans-unit>
+      <trans-unit id="S6M.YWY" resname="post.too_short_content">
+        <source>post.too_short_content</source>
+        <target>Bericht inhoud is te kort (minimaal { limit } karakters)</target>
+      </trans-unit>
+      <trans-unit id="ARUoKOV" resname="comment.blank">
+        <source>comment.blank</source>
+        <target>Vul alstublieft een reactie in.</target>
+      </trans-unit>
+      <trans-unit id="J.L_ppQ" resname="comment.too_short">
+        <source>comment.too_short</source>
+        <target>Reactie is te kort (minimaal { limit } karakters)</target>
+      </trans-unit>
+      <trans-unit id=".bkQKXb" resname="comment.too_long">
+        <source>comment.too_long</source>
+        <target>Reactie is te lang (maximaal { limit } karakters)</target>
+      </trans-unit>
+      <trans-unit id="cTT8h4_" resname="comment.is_spam">
+        <source>comment.is_spam</source>
+        <target>De inhoud van deze reactie wordt als spam gemarkeerd.</target>
+      </trans-unit>
+      <trans-unit id="EEehkgc" resname="post.slug_unique">
+        <source>post.slug_unique</source>
+        <target>De titel wordt al gebruikt in een andere blog post, maar de titel moet uniek zijn.</target>
+      </trans-unit>
+      <trans-unit id="niM7JYj" resname="post.too_many_tags">
+        <source>post.too_many_tags</source>
+        <target>Te veel tags toegevoegd (gebruik maximaal { limit } tags)</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>


### PR DESCRIPTION
As asked on [Slack](https://symfony-devs.slack.com/archives/C8WHX21K7/p1701681153225289)

- Ran `bin/console translation:extract --force nl` command, this caused the major update in the file. But I guess it should be the recommended way to extract the translations.
  - Running the command also added separate `security` and `validators` files. ~~If everybody uses the command above it may be logical to add them and have control over them in the demo application.~~ ~~Otherwise we could explicitly not add them as they seemed to be correctly translated already?~~ For now not added the extra generated files, this could be done later on for every language if we decide to.
- Added missing `label.remember_me` (for `en` and `nl`)