### PR TITLE
[Bootstrap v5] Fix the active links in the navigation

### DIFF
--- a/templates/admin/layout.html.twig
+++ b/templates/admin/layout.html.twig
@@ -13,8 +13,8 @@
 {% endblock %}
 
 {% block header_navigation_links %}
-    <li class="nav-item{{ _route in ['admin_index', 'admin_post_index'] ? ' active' : '' }}">
-        <a class="nav-link" href="{{ path('admin_post_index') }}">
+    <li class="nav-item">
+        <a class="nav-link {{- _route in ['admin_index', 'admin_post_index'] ? ' active' -}}" href="{{ path('admin_post_index') }}">
             <twig:ux:icon name="tabler:list"/> {{ 'menu.post_list'|trans }}
         </a>
     </li>

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -40,8 +40,8 @@
                         <div class="navbar-collapse collapse" id="appNavbar">
                             <ul class="navbar-nav ml-auto">
                                 {% block header_navigation_links %}
-                                    <li class="nav-item{{ _route == 'blog_index' ? ' active' : '' }}">
-                                        <a class="nav-link" href="{{ path('blog_index') }}">
+                                    <li class="nav-item">
+                                        <a class="nav-link {{- _route == 'blog_index' ? ' active' -}}" href="{{ path('blog_index') }}">
                                             <twig:ux:icon name="tabler:home"/> {{ 'menu.homepage'|trans }}
                                         </a>
                                     </li>
@@ -54,8 +54,10 @@
                                     {% endif %}
                                 {% endblock %}
 
-                                <li class="nav-item{{ _route == 'blog_search' ? ' active' : '' }}">
-                                    <a class="nav-link" href="{{ path('blog_search') }}"> <twig:ux:icon name="tabler:search"/> {{ 'menu.search'|trans }}</a>
+                                <li class="nav-item">
+                                    <a class="nav-link {{- _route == 'blog_search' ? ' active' -}}" href="{{ path('blog_search') }}">
+                                        <twig:ux:icon name="tabler:search"/> {{ 'menu.search'|trans }}
+                                    </a>
                                 </li>
 
                                 {% if app.user %}


### PR DESCRIPTION
For the navbar the .active class can no longer be applied to .nav-items, it must be applied directly on .nav-links.