### PR TITLE
[CI] Remove the redundant step "Build and compile assets"

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,11 +46,5 @@ jobs:
             - name: "Install dependencies"
               run: composer install --ansi --no-interaction --no-progress
 
-            - name: "Build and compile assets"
-              run: |
-                php bin/console importmap:install
-                php bin/console sass:build
-                php bin/console asset-map:compile
-
             - name: "Run tests"
               run: vendor/bin/phpunit


### PR DESCRIPTION
The step "Install dependencies" with `comoser install` also runs the commands `importmap:install` and `sass:build`.

Also I think the tests should be able to run without `asset-map:compile`.