### PR TITLE
Fix styles

### DIFF
--- a/assets/styles/_variables.scss
+++ b/assets/styles/_variables.scss
@@ -23,4 +23,4 @@ $btn-padding-x: 10px;
 $btn-padding-y-sm: 9px;
 $btn-padding-x-sm: 6px;
 
-@import "./bootswatch/variables";
+@import "./bootswatch/_variables.scss";


### PR DESCRIPTION
Without this change, I don't see any styles on the app and the server shows this:

```
[Application] Nov  4 14:19:23 |CRITICA| REQUES Uncaught PHP Exception 
Symfony\Component\AssetMapper\Exception\RuntimeException:
"Unable to find asset "./bootswatch/_variables" referenced in "demo/assets/styles/_variables.scss". 
The file "demo/assets/styles/bootswatch/_variables" does not exist."
at CssAssetUrlCompiler.php line 111
```