### PR TITLE
Update the namespace of AppExtensionTest

### DIFF
--- a/tests/Twig/AppExtensionTest.php
+++ b/tests/Twig/AppExtensionTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Twig;
+namespace App\Tests\Twig;
 
 use App\Twig\AppExtension;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
To reproduce run: `composer dump-autoload -o`

Fixes:
```
Class Twig\AppExtensionTest located in ./tests/Twig/AppExtensionTest.php does not comply with psr-4 autoloading standard (rule: App\Tests\ => ./tests). Skipping.
```
