### PR TITLE
Upgrade to MonologBundle v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "symfony/http-client": "^7",
         "symfony/intl": "^7",
         "symfony/mailer": "^7",
-        "symfony/monolog-bundle": "^3.7",
+        "symfony/monolog-bundle": "^4",
         "symfony/polyfill-intl-messageformatter": "^1.12",
         "symfony/runtime": "^7",
         "symfony/security-bundle": "^7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c8b29248b4f1c5ae7c5ce8b343e7f25f",
+    "content-hash": "80b23e534a2447e16dd2fd955b94a008",
     "packages": [
         {
             "name": "composer/semver",
@@ -1778,16 +1778,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "3.9.0",
+            "version": "3.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6"
+                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/10d85740180ecba7896c87e06a166e0c95a0e3b6",
-                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/b321dd6749f0bf7189444158a3ce785cc16d69b0",
+                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0",
                 "shasum": ""
             },
             "require": {
@@ -1805,7 +1805,7 @@
                 "graylog2/gelf-php": "^1.4.2 || ^2.0",
                 "guzzlehttp/guzzle": "^7.4.5",
                 "guzzlehttp/psr7": "^2.2",
-                "mongodb/mongodb": "^1.8",
+                "mongodb/mongodb": "^1.8 || ^2.0",
                 "php-amqplib/php-amqplib": "~2.4 || ^3",
                 "php-console/php-console": "^3.1.8",
                 "phpstan/phpstan": "^2",
@@ -1865,7 +1865,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/3.9.0"
+                "source": "https://github.com/Seldaek/monolog/tree/3.10.0"
             },
             "funding": [
                 {
@@ -1877,7 +1877,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-24T10:02:05+00:00"
+            "time": "2026-01-02T08:56:05+00:00"
         },
         {
             "name": "nette/schema",
@@ -4937,33 +4937,32 @@
         },
         {
             "name": "symfony/monolog-bundle",
-            "version": "v3.11.1",
+            "version": "v4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/monolog-bundle.git",
-                "reference": "0e675a6e08f791ef960dc9c7e392787111a3f0c1"
+                "reference": "3b4ee2717ee56c5e1edb516140a175eb2a72bc66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/monolog-bundle/zipball/0e675a6e08f791ef960dc9c7e392787111a3f0c1",
-                "reference": "0e675a6e08f791ef960dc9c7e392787111a3f0c1",
+                "url": "https://api.github.com/repos/symfony/monolog-bundle/zipball/3b4ee2717ee56c5e1edb516140a175eb2a72bc66",
+                "reference": "3b4ee2717ee56c5e1edb516140a175eb2a72bc66",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2.0",
-                "monolog/monolog": "^1.25.1 || ^2.0 || ^3.0",
-                "php": ">=8.1",
-                "symfony/config": "^6.4 || ^7.0",
-                "symfony/dependency-injection": "^6.4 || ^7.0",
-                "symfony/deprecation-contracts": "^2.5 || ^3.0",
-                "symfony/http-kernel": "^6.4 || ^7.0",
-                "symfony/monolog-bridge": "^6.4 || ^7.0",
+                "monolog/monolog": "^3.5",
+                "php": ">=8.2",
+                "symfony/config": "^7.3 || ^8.0",
+                "symfony/dependency-injection": "^7.3 || ^8.0",
+                "symfony/http-kernel": "^7.3 || ^8.0",
+                "symfony/monolog-bridge": "^7.3 || ^8.0",
                 "symfony/polyfill-php84": "^1.30"
             },
             "require-dev": {
-                "symfony/console": "^6.4 || ^7.0",
-                "symfony/phpunit-bridge": "^7.3.3",
-                "symfony/yaml": "^6.4 || ^7.0"
+                "phpunit/phpunit": "^11.5.41 || ^12.3",
+                "symfony/console": "^7.3 || ^8.0",
+                "symfony/yaml": "^7.3 || ^8.0"
             },
             "type": "symfony-bundle",
             "autoload": {
@@ -4993,7 +4992,7 @@
             ],
             "support": {
                 "issues": "https://github.com/symfony/monolog-bundle/issues",
-                "source": "https://github.com/symfony/monolog-bundle/tree/v3.11.1"
+                "source": "https://github.com/symfony/monolog-bundle/tree/v4.0.1"
             },
             "funding": [
                 {
@@ -5013,7 +5012,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-08T07:58:26+00:00"
+            "time": "2025-12-08T08:00:13+00:00"
         },
         {
             "name": "symfony/options-resolver",

--- a/config/reference.php
+++ b/config/reference.php
@@ -1242,7 +1242,6 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         bubble?: bool|Param, // Default: true
  *         interactive_only?: bool|Param, // Default: false
  *         app_name?: scalar|null|Param, // Default: null
- *         fill_extra_context?: bool|Param, // Default: false
  *         include_stacktraces?: bool|Param, // Default: false
  *         process_psr_3_messages?: array{
  *             enabled?: bool|null|Param, // Default: null
@@ -1262,7 +1261,6 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         activation_strategy?: scalar|null|Param, // Default: null
  *         stop_buffering?: bool|Param, // Default: true
  *         passthru_level?: scalar|null|Param, // Default: null
- *         excluded_404s?: list<scalar|null|Param>,
  *         excluded_http_codes?: list<array{ // Default: []
  *             code?: scalar|null|Param,
  *             urls?: list<scalar|null|Param>,
@@ -1276,9 +1274,6 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         url?: scalar|null|Param,
  *         exchange?: scalar|null|Param,
  *         exchange_name?: scalar|null|Param, // Default: "log"
- *         room?: scalar|null|Param,
- *         message_format?: scalar|null|Param, // Default: "text"
- *         api_version?: scalar|null|Param, // Default: null
  *         channel?: scalar|null|Param, // Default: null
  *         bot_name?: scalar|null|Param, // Default: "Monolog"
  *         use_attachment?: scalar|null|Param, // Default: true
@@ -1287,9 +1282,6 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         icon_emoji?: scalar|null|Param, // Default: null
  *         webhook_url?: scalar|null|Param,
  *         exclude_fields?: list<scalar|null|Param>,
- *         team?: scalar|null|Param,
- *         notify?: scalar|null|Param, // Default: false
- *         nickname?: scalar|null|Param, // Default: "Monolog"
  *         token?: scalar|null|Param,
  *         region?: scalar|null|Param,
  *         source?: scalar|null|Param,
@@ -1307,12 +1299,6 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         store?: scalar|null|Param, // Default: null
  *         connection_timeout?: scalar|null|Param,
  *         persistent?: bool|Param,
- *         dsn?: scalar|null|Param,
- *         hub_id?: scalar|null|Param, // Default: null
- *         client_id?: scalar|null|Param, // Default: null
- *         auto_log_stacks?: scalar|null|Param, // Default: false
- *         release?: scalar|null|Param, // Default: null
- *         environment?: scalar|null|Param, // Default: null
  *         message_type?: scalar|null|Param, // Default: 0
  *         parse_mode?: scalar|null|Param, // Default: null
  *         disable_webpage_preview?: bool|null|Param, // Default: null
@@ -1322,7 +1308,6 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         topic?: int|Param, // Default: null
  *         factor?: int|Param, // Default: 1
  *         tags?: list<scalar|null|Param>,
- *         console_formater_options?: mixed, // Deprecated: "monolog.handlers..console_formater_options.console_formater_options" is deprecated, use "monolog.handlers..console_formater_options.console_formatter_options" instead.
  *         console_formatter_options?: mixed, // Default: []
  *         formatter?: scalar|null|Param,
  *         nested?: bool|Param, // Default: false
@@ -1332,15 +1317,6 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             port?: scalar|null|Param, // Default: 12201
  *             chunk_size?: scalar|null|Param, // Default: 1420
  *             encoder?: "json"|"compressed_json"|Param,
- *         },
- *         mongo?: string|array{
- *             id?: scalar|null|Param,
- *             host?: scalar|null|Param,
- *             port?: scalar|null|Param, // Default: 27017
- *             user?: scalar|null|Param,
- *             pass?: scalar|null|Param,
- *             database?: scalar|null|Param, // Default: "monolog"
- *             collection?: scalar|null|Param, // Default: "logs"
  *         },
  *         mongodb?: string|array{
  *             id?: scalar|null|Param, // ID of a MongoDB\Client service
@@ -1384,7 +1360,6 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             id: scalar|null|Param,
  *             method?: scalar|null|Param, // Default: null
  *         },
- *         lazy?: bool|Param, // Default: true
  *         verbosity_levels?: array{
  *             VERBOSITY_QUIET?: scalar|null|Param, // Default: "ERROR"
  *             VERBOSITY_NORMAL?: scalar|null|Param, // Default: "WARNING"


### PR DESCRIPTION
The `reference.php` file is updated because we removed many configuration keys in [MonologBundle v4.0.0](https://github.com/symfony/monolog-bundle/releases/tag/v4.0.0).