### PR TITLE
Remove double wildcard on AssetMapper `excluded_patterns` configuration

### DIFF
--- a/config/packages/asset_mapper.yaml
+++ b/config/packages/asset_mapper.yaml
@@ -5,7 +5,7 @@ framework:
             - assets/
         missing_import_mode: strict
         excluded_patterns:
-            - '**/assets/styles/**/_*.scss'
+            - '*/assets/styles/**/_*.scss'
 
 when@prod:
     framework:


### PR DESCRIPTION
Related to https://github.com/symfony/symfony/issues/61771 and https://github.com/symfony/ux/pull/3285
